### PR TITLE
feat(cursor): liquid glass water drop that swells into a magnifier

### DIFF
--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -80,36 +80,52 @@ body.fs-cursor-active * {
   cursor: none;
 }
 
-/* Animated cursor: a thin ring at rest, a liquid glass magnifier over interactive elements. */
+/* Animated cursor: a liquid glass water drop that swells into a magnifier over interactive elements. */
 .fs-lens {
-  border-radius: 50%;
-  border: 1px solid var(--color-accent-300);
-  transition: border-color .4s ease, background .4s ease, box-shadow .4s ease, backdrop-filter .4s ease;
-}
-
-.fs-lens.is-magnifying {
-  border-color: rgba(233, 233, 237, .5);
+  /* Driven per frame from the drop's own velocity: tail sharpness, glass strength, rim shine. */
+  --fs-drop-tail: 50%;
+  --fs-glass: 0;
+  --fs-shine: 0;
+  /* The trailing edge (left, in the drop's own rotated frame) pulls into a tail as it travels. */
+  border-radius: var(--fs-drop-tail) 50% 50% var(--fs-drop-tail) / 50% 50% 50% 50%;
+  border: 1px solid rgba(210, 206, 253, calc(.45 + var(--fs-glass) * .2));
   background: radial-gradient(circle at 50% 50%,
-    transparent 55%,
-    rgba(255, 255, 255, .04) 80%,
-    rgba(145, 132, 217, .10) 100%);
-  -webkit-backdrop-filter: blur(6px) saturate(165%) brightness(.86);
-  backdrop-filter: blur(6px) saturate(165%) brightness(.86);
+    transparent 45%,
+    rgba(255, 255, 255, calc(.03 + var(--fs-glass) * .02)) 80%,
+    rgba(145, 132, 217, calc(.10 + var(--fs-glass) * .04)) 100%);
+  -webkit-backdrop-filter:
+    blur(calc(1px + var(--fs-glass) * 5px))
+    saturate(calc(140% + var(--fs-glass) * 25%))
+    brightness(calc(1.12 - var(--fs-glass) * .26));
+  backdrop-filter:
+    blur(calc(1px + var(--fs-glass) * 5px))
+    saturate(calc(140% + var(--fs-glass) * 25%))
+    brightness(calc(1.12 - var(--fs-glass) * .26));
   box-shadow:
     inset 0 1px 1px rgba(255, 255, 255, .45),
-    inset 0 0 0 1px rgba(22, 24, 38, .5),
-    inset 0 0 10px rgba(145, 132, 217, .16),
-    0 12px 30px rgba(0, 0, 0, .5);
-  animation: fs-lens-liquid 6s ease-in-out infinite;
+    inset 0 0 0 1px rgba(22, 24, 38, calc(var(--fs-glass) * .5)),
+    inset 0 0 10px rgba(145, 132, 217, calc(.08 + var(--fs-glass) * .08)),
+    0 6px 16px rgba(0, 0, 0, calc(.22 + var(--fs-glass) * .28));
+  will-change: transform;
 }
 
-/* Holds the magnified copy of the hovered element, clipped to the (morphing) lens shape. */
+/* Holds the magnified copy of the hovered element, clipped to the drop's current shape. */
 .fs-lens-content {
   position: absolute;
   inset: 0;
   overflow: hidden;
   border-radius: inherit;
   isolation: isolate;
+}
+
+/*
+ * Counter-rotated against the drop, so the magnified content and the specular stay world-upright
+ * while the drop itself leans into the movement. What is left over is a directional stretch.
+ */
+.fs-lens-upright,
+.fs-lens-glare {
+  position: absolute;
+  inset: 0;
 }
 
 .fs-lens-clone,
@@ -121,16 +137,14 @@ body.fs-cursor-active * {
 }
 
 .fs-lens-refraction,
-.fs-lens-sheen,
-.fs-lens-glare {
+.fs-lens-sheen {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  opacity: 0;
-  transition: opacity .35s ease;
+  opacity: var(--fs-shine);
 }
 
-/* Light bending at the rim, where a real lens distorts the most. */
+/* Light bending at the rim, where a drop of water distorts the most. */
 .fs-lens-refraction {
   background:
     radial-gradient(circle at 50% 50%, transparent 58%, rgba(255, 255, 255, .06) 74%, rgba(210, 206, 253, .22) 88%, rgba(255, 255, 255, .42) 96%, transparent 100%),
@@ -138,7 +152,7 @@ body.fs-cursor-active * {
   mix-blend-mode: screen;
 }
 
-/* Highlight travelling around the rim, which gives the glass its liquid feel. */
+/* Highlight travelling around the rim, which keeps the glass alive while the drop rests. */
 .fs-lens-sheen {
   border-radius: 50%;
   background: conic-gradient(from 0deg,
@@ -153,31 +167,18 @@ body.fs-cursor-active * {
   animation: fs-lens-spin 7s linear infinite;
 }
 
-/* Specular arcs: small and close to the rim, the way light catches a real lens. */
+/* Specular arcs: small and close to the rim, the way light catches water. */
 .fs-lens-glare {
   background:
-    radial-gradient(22% 16% at 28% 17%, rgba(255, 255, 255, .55), transparent 100%),
-    radial-gradient(14% 10% at 72% 84%, rgba(210, 206, 253, .3), transparent 100%);
-}
-
-.fs-lens.is-magnifying .fs-lens-refraction,
-.fs-lens.is-magnifying .fs-lens-sheen,
-.fs-lens.is-magnifying .fs-lens-glare {
-  opacity: 1;
+    radial-gradient(22% 16% at 28% 17%, rgba(255, 255, 255, calc(.35 + var(--fs-glass) * .2)), transparent 100%),
+    radial-gradient(14% 10% at 72% 84%, rgba(210, 206, 253, calc(.18 + var(--fs-glass) * .12)), transparent 100%);
 }
 
 @keyframes fs-lens-spin {
   to { transform: rotate(360deg); }
 }
 
-@keyframes fs-lens-liquid {
-  0%, 100% { border-radius: 50% 50% 50% 50% / 50% 50% 50% 50%; }
-  33% { border-radius: 54% 46% 49% 51% / 47% 53% 47% 53%; }
-  66% { border-radius: 47% 53% 52% 48% / 52% 48% 53% 47%; }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .fs-lens.is-magnifying,
   .fs-lens-sheen {
     animation: none;
   }

--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -80,6 +80,21 @@ body.fs-cursor-active * {
   cursor: none;
 }
 
+/*
+ * The cursor layers ride in the top layer (via popover) so a native <dialog> modal cannot cover
+ * them. These undo the parts of the UA popover box the cursor styles do not already replace, and
+ * must stay above .fs-lens so its own border still wins.
+ */
+.fs-cursor-layer {
+  right: auto;
+  bottom: auto;
+  margin: 0;
+  padding: 0;
+  border-width: 0;
+  overflow: visible;
+  color: inherit;
+}
+
 /* Animated cursor: a liquid glass water drop that swells into a magnifier over interactive elements. */
 .fs-lens {
   /* Driven per frame from the drop's own velocity: tail sharpness, glass strength, rim shine. */

--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -80,6 +80,109 @@ body.fs-cursor-active * {
   cursor: none;
 }
 
+/* Animated cursor: a thin ring at rest, a liquid glass magnifier over interactive elements. */
+.fs-lens {
+  border-radius: 50%;
+  border: 1px solid var(--color-accent-300);
+  transition: border-color .4s ease, background .4s ease, box-shadow .4s ease, backdrop-filter .4s ease;
+}
+
+.fs-lens.is-magnifying {
+  border-color: rgba(233, 233, 237, .5);
+  background: radial-gradient(circle at 50% 50%,
+    transparent 55%,
+    rgba(255, 255, 255, .04) 80%,
+    rgba(145, 132, 217, .10) 100%);
+  -webkit-backdrop-filter: blur(6px) saturate(165%) brightness(.86);
+  backdrop-filter: blur(6px) saturate(165%) brightness(.86);
+  box-shadow:
+    inset 0 1px 1px rgba(255, 255, 255, .45),
+    inset 0 0 0 1px rgba(22, 24, 38, .5),
+    inset 0 0 10px rgba(145, 132, 217, .16),
+    0 12px 30px rgba(0, 0, 0, .5);
+  animation: fs-lens-liquid 6s ease-in-out infinite;
+}
+
+/* Holds the magnified copy of the hovered element, clipped to the (morphing) lens shape. */
+.fs-lens-content {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border-radius: inherit;
+  isolation: isolate;
+}
+
+.fs-lens-clone,
+.fs-lens-clone * {
+  animation: none !important;
+  transition: none !important;
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}
+
+.fs-lens-refraction,
+.fs-lens-sheen,
+.fs-lens-glare {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  opacity: 0;
+  transition: opacity .35s ease;
+}
+
+/* Light bending at the rim, where a real lens distorts the most. */
+.fs-lens-refraction {
+  background:
+    radial-gradient(circle at 50% 50%, transparent 58%, rgba(255, 255, 255, .06) 74%, rgba(210, 206, 253, .22) 88%, rgba(255, 255, 255, .42) 96%, transparent 100%),
+    radial-gradient(circle at 50% 50%, transparent 76%, rgba(145, 132, 217, .30) 93%, transparent 100%);
+  mix-blend-mode: screen;
+}
+
+/* Highlight travelling around the rim, which gives the glass its liquid feel. */
+.fs-lens-sheen {
+  border-radius: 50%;
+  background: conic-gradient(from 0deg,
+    transparent 0deg,
+    rgba(255, 255, 255, .34) 26deg,
+    transparent 62deg,
+    transparent 180deg,
+    rgba(210, 206, 253, .24) 214deg,
+    transparent 250deg);
+  -webkit-mask: radial-gradient(circle, transparent 58%, #000 78%, #000 100%);
+  mask: radial-gradient(circle, transparent 58%, #000 78%, #000 100%);
+  animation: fs-lens-spin 7s linear infinite;
+}
+
+/* Specular arcs: small and close to the rim, the way light catches a real lens. */
+.fs-lens-glare {
+  background:
+    radial-gradient(22% 16% at 28% 17%, rgba(255, 255, 255, .55), transparent 100%),
+    radial-gradient(14% 10% at 72% 84%, rgba(210, 206, 253, .3), transparent 100%);
+}
+
+.fs-lens.is-magnifying .fs-lens-refraction,
+.fs-lens.is-magnifying .fs-lens-sheen,
+.fs-lens.is-magnifying .fs-lens-glare {
+  opacity: 1;
+}
+
+@keyframes fs-lens-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes fs-lens-liquid {
+  0%, 100% { border-radius: 50% 50% 50% 50% / 50% 50% 50% 50%; }
+  33% { border-radius: 54% 46% 49% 51% / 47% 53% 47% 53%; }
+  66% { border-radius: 47% 53% 52% 48% / 52% 48% 53% 47%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fs-lens.is-magnifying,
+  .fs-lens-sheen {
+    animation: none;
+  }
+}
+
 @keyframes fs-float {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-8px); }

--- a/src/pages/home/components/custom-cursor.tsx
+++ b/src/pages/home/components/custom-cursor.tsx
@@ -4,17 +4,20 @@ import {useCustomCursor} from "@/pages/home/hooks/useCustomCursor.ts";
 export const CustomCursor = () => {
   const dotRef = useRef<HTMLDivElement>(null);
   const lensRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
+  const uprightRef = useRef<HTMLDivElement>(null);
+  const glareRef = useRef<HTMLDivElement>(null);
 
-  useCustomCursor(dotRef, lensRef, contentRef);
+  useCustomCursor(dotRef, lensRef, uprightRef, glareRef);
 
   return <>
     <div ref={dotRef} aria-hidden className="pointer-events-none fixed top-0 left-0 z-9999 size-1.5 rounded-full bg-accent hidden [body.fs-cursor-active_&]:block"/>
     <div ref={lensRef} aria-hidden className="fs-lens pointer-events-none fixed top-0 left-0 z-9999 hidden [body.fs-cursor-active_&]:block">
-      <div ref={contentRef} className="fs-lens-content"/>
+      <div className="fs-lens-content">
+        <div ref={uprightRef} className="fs-lens-upright"/>
+        <div ref={glareRef} className="fs-lens-glare"/>
+      </div>
       <div className="fs-lens-refraction"/>
       <div className="fs-lens-sheen"/>
-      <div className="fs-lens-glare"/>
     </div>
   </>
 };

--- a/src/pages/home/components/custom-cursor.tsx
+++ b/src/pages/home/components/custom-cursor.tsx
@@ -3,12 +3,18 @@ import {useCustomCursor} from "@/pages/home/hooks/useCustomCursor.ts";
 
 export const CustomCursor = () => {
   const dotRef = useRef<HTMLDivElement>(null);
-  const ringRef = useRef<HTMLDivElement>(null);
+  const lensRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
-  useCustomCursor(dotRef, ringRef);
+  useCustomCursor(dotRef, lensRef, contentRef);
 
   return <>
-    <div ref={dotRef} className="pointer-events-none fixed top-0 left-0 z-9999 size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent hidden [body.fs-cursor-active_&]:block"/>
-    <div ref={ringRef} className="pointer-events-none fixed top-0 left-0 z-9999 size-8.5 -translate-x-1/2 -translate-y-1/2 rounded-full border border-accent-300 hidden [body.fs-cursor-active_&]:block"/>
+    <div ref={dotRef} aria-hidden className="pointer-events-none fixed top-0 left-0 z-9999 size-1.5 rounded-full bg-accent hidden [body.fs-cursor-active_&]:block"/>
+    <div ref={lensRef} aria-hidden className="fs-lens pointer-events-none fixed top-0 left-0 z-9999 hidden [body.fs-cursor-active_&]:block">
+      <div ref={contentRef} className="fs-lens-content"/>
+      <div className="fs-lens-refraction"/>
+      <div className="fs-lens-sheen"/>
+      <div className="fs-lens-glare"/>
+    </div>
   </>
 };

--- a/src/pages/home/components/custom-cursor.tsx
+++ b/src/pages/home/components/custom-cursor.tsx
@@ -1,6 +1,11 @@
 import {useRef} from "react";
+import {createPortal} from "react-dom";
 import {useCustomCursor} from "@/pages/home/hooks/useCustomCursor.ts";
 
+/*
+ * Rendered straight into <body> and promoted to the top layer, so neither a nested stacking
+ * context nor a native <dialog> modal can end up painting over the drop.
+ */
 export const CustomCursor = () => {
   const dotRef = useRef<HTMLDivElement>(null);
   const lensRef = useRef<HTMLDivElement>(null);
@@ -9,9 +14,11 @@ export const CustomCursor = () => {
 
   useCustomCursor(dotRef, lensRef, uprightRef, glareRef);
 
-  return <>
-    <div ref={dotRef} aria-hidden className="pointer-events-none fixed top-0 left-0 z-9999 size-1.5 rounded-full bg-accent hidden [body.fs-cursor-active_&]:block"/>
-    <div ref={lensRef} aria-hidden className="fs-lens pointer-events-none fixed top-0 left-0 z-9999 hidden [body.fs-cursor-active_&]:block">
+  if (typeof document === "undefined") return null;
+
+  return createPortal(<>
+    <div ref={dotRef} aria-hidden popover="manual" className="fs-cursor-layer pointer-events-none fixed top-0 left-0 z-[2147483647] size-1.5 rounded-full bg-accent hidden [body.fs-cursor-active_&]:block"/>
+    <div ref={lensRef} aria-hidden popover="manual" className="fs-cursor-layer fs-lens pointer-events-none fixed top-0 left-0 z-[2147483647] hidden [body.fs-cursor-active_&]:block">
       <div className="fs-lens-content">
         <div ref={uprightRef} className="fs-lens-upright"/>
         <div ref={glareRef} className="fs-lens-glare"/>
@@ -19,5 +26,5 @@ export const CustomCursor = () => {
       <div className="fs-lens-refraction"/>
       <div className="fs-lens-sheen"/>
     </div>
-  </>
+  </>, document.body);
 };

--- a/src/pages/home/hooks/useCustomCursor.ts
+++ b/src/pages/home/hooks/useCustomCursor.ts
@@ -2,6 +2,8 @@ import {useLayoutEffect, type RefObject} from "react";
 import gsap from "gsap";
 
 const HOVER_SELECTOR = "a, button, [data-fs-hover]";
+/** Elements that get promoted to the top layer, where plain z-index no longer applies. */
+const TOP_LAYER_SELECTOR = "dialog[open], [popover]";
 
 /** Resting droplet diameter, in px. */
 const IDLE_SIZE = 30;
@@ -241,17 +243,53 @@ export const useCustomCursor = (
       if (target) release();
     };
 
+    /*
+     * The top layer is ordered by promotion, not by z-index, so the drop has to re-enter it every
+     * time something else joins — otherwise a modal <dialog> opened later paints over it.
+     */
+    const promote = () => {
+      [dot, lens].forEach((layer) => {
+        if (typeof layer.showPopover !== "function") return;
+        try {
+          if (layer.matches(":popover-open")) layer.hidePopover();
+          layer.showPopover();
+        } catch {
+          /* Browsers without the popover API fall back to plain z-index stacking. */
+        }
+      });
+    };
+
+    const joinsTopLayer = (node: Node) =>
+      node instanceof HTMLElement && (node.matches(TOP_LAYER_SELECTOR) || node.querySelector(TOP_LAYER_SELECTOR) !== null);
+
+    const topLayerWatcher = new MutationObserver((records) => {
+      const joined = records.some((record) =>
+        record.type === "attributes"
+          ? record.target instanceof HTMLElement && record.target.matches(TOP_LAYER_SELECTOR)
+          : Array.from(record.addedNodes).some(joinsTopLayer),
+      );
+      if (joined) promote();
+    });
+
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseover", onOver);
     document.addEventListener("mouseleave", onLeave);
     document.body.classList.add("fs-cursor-active");
     gsap.ticker.add(frame);
+    promote();
+    topLayerWatcher.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["open", "popover"],
+    });
 
     return () => {
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseover", onOver);
       document.removeEventListener("mouseleave", onLeave);
       document.body.classList.remove("fs-cursor-active");
+      topLayerWatcher.disconnect();
       gsap.ticker.remove(frame);
       gsap.killTweensOf([lensState, dot, lens]);
       upright.replaceChildren();

--- a/src/pages/home/hooks/useCustomCursor.ts
+++ b/src/pages/home/hooks/useCustomCursor.ts
@@ -3,14 +3,27 @@ import gsap from "gsap";
 
 const HOVER_SELECTOR = "a, button, [data-fs-hover]";
 
-/** Idle ring diameter, in px. */
-const IDLE_SIZE = 34;
-/** Lens diameter while magnifying, in px. */
+/** Resting droplet diameter, in px. */
+const IDLE_SIZE = 30;
+/** Droplet diameter while magnifying, in px. */
 const LENS_SIZE = 104;
-/** How much the content under the lens is scaled up. */
+/** How much the content under the droplet is scaled up. */
 const MAGNIFICATION = 1.75;
 /** Targets bigger than this (in px²) get the glass, but no magnified copy. */
 const MAX_CLONE_AREA = 1_400_000;
+
+/*
+ * Droplet physics. The drop stretches along its direction of travel and springs back into a bead
+ * once it settles, which is what reads as liquid rather than as a moving circle.
+ */
+const STRETCH_IDLE = 0.34;
+const STRETCH_MAGNIFYING = 0.16;
+/** Speed (px/s) at which the drop reaches its full stretch. */
+const SPEED_FOR_MAX_STRETCH = 2600;
+const SPRING_STIFFNESS = 210;
+const SPRING_DAMPING = 15;
+/** Below this speed (px/s) the drop keeps its last orientation instead of chasing noise. */
+const MIN_SPEED_FOR_ANGLE = 40;
 
 /* Inherited properties the clone cannot resolve on its own (they come from ancestors). */
 const INHERITED_PROPS = [
@@ -25,6 +38,12 @@ const INHERITED_PROPS = [
   "text-transform",
   "white-space",
 ] as const;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+/** Moves an angle towards another one the short way around, so 350° → 10° does not spin backwards. */
+const approachAngle = (current: number, goal: number, ratio: number) =>
+  current + (((goal - current + 540) % 360) - 180) * ratio;
 
 const buildClone = (source: HTMLElement) => {
   const clone = source.cloneNode(true) as HTMLElement;
@@ -50,15 +69,18 @@ const buildClone = (source: HTMLElement) => {
 export const useCustomCursor = (
   dotRef: RefObject<HTMLDivElement | null>,
   lensRef: RefObject<HTMLDivElement | null>,
-  contentRef: RefObject<HTMLDivElement | null>,
+  uprightRef: RefObject<HTMLDivElement | null>,
+  glareRef: RefObject<HTMLDivElement | null>,
 ) => {
   useLayoutEffect(() => {
     if (!window.matchMedia("(pointer: fine)").matches) return;
-    if (!dotRef.current || !lensRef.current || !contentRef.current) return;
+    if (!dotRef.current || !lensRef.current) return;
+    if (!uprightRef.current || !glareRef.current) return;
 
     const dot = dotRef.current;
     const lens = lensRef.current;
-    const content = contentRef.current;
+    const upright = uprightRef.current;
+    const glare = glareRef.current;
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
     gsap.set([dot, lens], {xPercent: -50, yPercent: -50, x: -200, y: -200});
@@ -68,21 +90,73 @@ export const useCustomCursor = (
     const moveDotY = gsap.quickTo(dot, "y", {duration: 0.1, ease: "power3"});
     const moveLensX = gsap.quickTo(lens, "x", {duration: 0.35, ease: "power3"});
     const moveLensY = gsap.quickTo(lens, "y", {duration: 0.35, ease: "power3"});
+    const setRotation = gsap.quickSetter(lens, "rotation", "deg") as (value: number) => void;
+    const setScaleX = gsap.quickSetter(lens, "scaleX") as (value: number) => void;
+    const setScaleY = gsap.quickSetter(lens, "scaleY") as (value: number) => void;
 
-    /* Animated through gsap so the lens can grow and focus with a single elastic tween. */
-    const lensState = {size: IDLE_SIZE, magnification: 1};
+    /* Animated through gsap so the drop can swell into the lens with a single elastic tween. */
+    const lensState = {size: IDLE_SIZE, magnification: 1, glass: 0};
 
     let target: HTMLElement | null = null;
     let clone: HTMLElement | null = null;
     let lastSize = "";
-    let syncing = false;
+    let lastSpin = "";
+
+    /* Spring state of the droplet, driven by how fast the drop itself is travelling. */
+    let previousX = -200;
+    let previousY = -200;
+    let stretch = 0;
+    let stretchVelocity = 0;
+    let angle = 0;
 
     /*
-     * Keeps the magnified copy locked to whatever the lens is currently sitting on: the lens lags
-     * behind the pointer, so the geometry is derived from the lens' own animated position, not from
-     * the raw cursor coordinates.
+     * Deforms the drop, then keeps the magnified copy locked to whatever the lens is sitting on:
+     * the lens lags behind the pointer, so the geometry is derived from the lens' own animated
+     * position rather than from the raw cursor coordinates.
      */
-    const sync = () => {
+    const frame = (_time: number, delta: number) => {
+      /* Clamped so a backgrounded tab does not resume with one enormous step. */
+      const step = Math.min(delta, 34) / 1000;
+      const lensX = gsap.getProperty(lens, "x") as number;
+      const lensY = gsap.getProperty(lens, "y") as number;
+      const travelX = lensX - previousX;
+      const travelY = lensY - previousY;
+      previousX = lensX;
+      previousY = lensY;
+
+      if (!reduceMotion && step > 0) {
+        const speed = Math.hypot(travelX, travelY) / step;
+
+        if (speed > MIN_SPEED_FOR_ANGLE) {
+          const heading = (Math.atan2(travelY, travelX) * 180) / Math.PI;
+          angle = approachAngle(angle, heading, Math.min(1, step * 18));
+        }
+
+        const limit = target ? STRETCH_MAGNIFYING : STRETCH_IDLE;
+        const goal = Math.min(speed / SPEED_FOR_MAX_STRETCH, 1) * limit;
+        stretchVelocity += ((goal - stretch) * SPRING_STIFFNESS - stretchVelocity * SPRING_DAMPING) * step;
+        stretch = clamp(stretch + stretchVelocity * step, -0.25, 0.6);
+
+        /* Stretching along the heading while squeezing across it keeps the volume believable. */
+        setRotation(angle);
+        setScaleX(1 + stretch);
+        setScaleY(1 / (1 + stretch));
+
+        const spin = `rotate(${-angle}deg)`;
+        if (spin !== lastSpin) {
+          /* The clone and the specular stay world-upright while the drop itself leans into the move. */
+          upright.style.transform = spin;
+          glare.style.transform = spin;
+          lastSpin = spin;
+        }
+      }
+
+      const pull = clamp(stretch / STRETCH_IDLE, 0, 1);
+      /* The trailing edge sharpens into a tail as the drop picks up speed. */
+      lens.style.setProperty("--fs-drop-tail", `${50 - pull * (target ? 12 : 30)}%`);
+      lens.style.setProperty("--fs-glass", `${Math.max(0, lensState.glass)}`);
+      lens.style.setProperty("--fs-shine", `${clamp(0.3 + lensState.glass * 0.45 + pull * 0.25, 0, 1)}`);
+
       const size = `${lensState.size}px`;
       if (size !== lastSize) {
         lens.style.width = size;
@@ -98,8 +172,6 @@ export const useCustomCursor = (
       }
 
       const rect = target.getBoundingClientRect();
-      const lensX = gsap.getProperty(lens, "x") as number;
-      const lensY = gsap.getProperty(lens, "y") as number;
       /* Point of the target that has to stay pinned to the centre of the lens. */
       const focusX = lensX - rect.left;
       const focusY = lensY - rect.top;
@@ -113,37 +185,24 @@ export const useCustomCursor = (
       clone.style.transform = `scale(${lensState.magnification})`;
     };
 
-    const startSync = () => {
-      if (syncing) return;
-      gsap.ticker.add(sync);
-      syncing = true;
-    };
-
-    const stopSync = () => {
-      if (!syncing) return;
-      gsap.ticker.remove(sync);
-      syncing = false;
-    };
-
     const magnify = (element: HTMLElement) => {
       target = element;
       const rect = element.getBoundingClientRect();
 
-      content.replaceChildren();
+      upright.replaceChildren();
       clone = rect.width * rect.height <= MAX_CLONE_AREA ? buildClone(element) : null;
-      if (clone) content.appendChild(clone);
+      if (clone) upright.appendChild(clone);
 
       lens.classList.add("is-magnifying");
       gsap.killTweensOf(lensState);
       gsap.to(lensState, {
         size: LENS_SIZE,
         magnification: MAGNIFICATION,
+        glass: 1,
         duration: reduceMotion ? 0.2 : 0.55,
         ease: reduceMotion ? "power2.out" : "elastic.out(1, 0.72)",
       });
       gsap.to(dot, {opacity: 0, scale: 0.4, duration: 0.25, ease: "power2.out"});
-      startSync();
-      sync();
     };
 
     const release = () => {
@@ -153,12 +212,12 @@ export const useCustomCursor = (
       gsap.to(lensState, {
         size: IDLE_SIZE,
         magnification: 1,
+        glass: 0,
         duration: reduceMotion ? 0.15 : 0.35,
         ease: "power3.out",
         onComplete: () => {
-          content.replaceChildren();
+          upright.replaceChildren();
           clone = null;
-          stopSync();
         },
       });
       gsap.to(dot, {opacity: 1, scale: 1, duration: 0.25, ease: "power2.out"});
@@ -186,15 +245,16 @@ export const useCustomCursor = (
     document.addEventListener("mouseover", onOver);
     document.addEventListener("mouseleave", onLeave);
     document.body.classList.add("fs-cursor-active");
+    gsap.ticker.add(frame);
 
     return () => {
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseover", onOver);
       document.removeEventListener("mouseleave", onLeave);
       document.body.classList.remove("fs-cursor-active");
+      gsap.ticker.remove(frame);
       gsap.killTweensOf([lensState, dot, lens]);
-      stopSync();
-      content.replaceChildren();
+      upright.replaceChildren();
     };
-  }, [dotRef, lensRef, contentRef]);
+  }, [dotRef, lensRef, uprightRef, glareRef]);
 };

--- a/src/pages/home/hooks/useCustomCursor.ts
+++ b/src/pages/home/hooks/useCustomCursor.ts
@@ -1,49 +1,200 @@
 import {useLayoutEffect, type RefObject} from "react";
 import gsap from "gsap";
 
+const HOVER_SELECTOR = "a, button, [data-fs-hover]";
+
+/** Idle ring diameter, in px. */
+const IDLE_SIZE = 34;
+/** Lens diameter while magnifying, in px. */
+const LENS_SIZE = 104;
+/** How much the content under the lens is scaled up. */
+const MAGNIFICATION = 1.75;
+/** Targets bigger than this (in px²) get the glass, but no magnified copy. */
+const MAX_CLONE_AREA = 1_400_000;
+
+/* Inherited properties the clone cannot resolve on its own (they come from ancestors). */
+const INHERITED_PROPS = [
+  "color",
+  "font-family",
+  "font-size",
+  "font-weight",
+  "font-style",
+  "letter-spacing",
+  "line-height",
+  "text-align",
+  "text-transform",
+  "white-space",
+] as const;
+
+const buildClone = (source: HTMLElement) => {
+  const clone = source.cloneNode(true) as HTMLElement;
+
+  clone.removeAttribute("id");
+  clone.querySelectorAll("[id]").forEach((node) => node.removeAttribute("id"));
+  clone.setAttribute("aria-hidden", "true");
+  clone.classList.add("fs-lens-clone");
+
+  const computed = getComputedStyle(source);
+  INHERITED_PROPS.forEach((prop) => clone.style.setProperty(prop, computed.getPropertyValue(prop)));
+
+  clone.style.position = "absolute";
+  clone.style.margin = "0";
+  clone.style.maxWidth = "none";
+  clone.style.maxHeight = "none";
+  clone.style.pointerEvents = "none";
+  clone.style.willChange = "transform";
+
+  return clone;
+};
+
 export const useCustomCursor = (
   dotRef: RefObject<HTMLDivElement | null>,
-  ringRef: RefObject<HTMLDivElement | null>,
+  lensRef: RefObject<HTMLDivElement | null>,
+  contentRef: RefObject<HTMLDivElement | null>,
 ) => {
   useLayoutEffect(() => {
     if (!window.matchMedia("(pointer: fine)").matches) return;
-    if (!dotRef.current || !ringRef.current) return;
+    if (!dotRef.current || !lensRef.current || !contentRef.current) return;
 
     const dot = dotRef.current;
-    const ring = ringRef.current;
+    const lens = lensRef.current;
+    const content = contentRef.current;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-    const moveDot = gsap.quickTo(dot, "x", {duration: 0.1, ease: "power3"});
+    gsap.set([dot, lens], {xPercent: -50, yPercent: -50, x: -200, y: -200});
+    gsap.set(lens, {width: IDLE_SIZE, height: IDLE_SIZE});
+
+    const moveDotX = gsap.quickTo(dot, "x", {duration: 0.1, ease: "power3"});
     const moveDotY = gsap.quickTo(dot, "y", {duration: 0.1, ease: "power3"});
-    const moveRing = gsap.quickTo(ring, "x", {duration: 0.35, ease: "power3"});
-    const moveRingY = gsap.quickTo(ring, "y", {duration: 0.35, ease: "power3"});
+    const moveLensX = gsap.quickTo(lens, "x", {duration: 0.35, ease: "power3"});
+    const moveLensY = gsap.quickTo(lens, "y", {duration: 0.35, ease: "power3"});
+
+    /* Animated through gsap so the lens can grow and focus with a single elastic tween. */
+    const lensState = {size: IDLE_SIZE, magnification: 1};
+
+    let target: HTMLElement | null = null;
+    let clone: HTMLElement | null = null;
+    let lastSize = "";
+    let syncing = false;
+
+    /*
+     * Keeps the magnified copy locked to whatever the lens is currently sitting on: the lens lags
+     * behind the pointer, so the geometry is derived from the lens' own animated position, not from
+     * the raw cursor coordinates.
+     */
+    const sync = () => {
+      const size = `${lensState.size}px`;
+      if (size !== lastSize) {
+        lens.style.width = size;
+        lens.style.height = size;
+        lastSize = size;
+      }
+
+      if (!clone || !target) return;
+      /* The hovered element can disappear under the cursor (carousels, modals, route changes). */
+      if (!target.isConnected) {
+        release();
+        return;
+      }
+
+      const rect = target.getBoundingClientRect();
+      const lensX = gsap.getProperty(lens, "x") as number;
+      const lensY = gsap.getProperty(lens, "y") as number;
+      /* Point of the target that has to stay pinned to the centre of the lens. */
+      const focusX = lensX - rect.left;
+      const focusY = lensY - rect.top;
+      const radius = lensState.size / 2;
+
+      clone.style.left = `${radius - focusX}px`;
+      clone.style.top = `${radius - focusY}px`;
+      clone.style.width = `${rect.width}px`;
+      clone.style.height = `${rect.height}px`;
+      clone.style.transformOrigin = `${focusX}px ${focusY}px`;
+      clone.style.transform = `scale(${lensState.magnification})`;
+    };
+
+    const startSync = () => {
+      if (syncing) return;
+      gsap.ticker.add(sync);
+      syncing = true;
+    };
+
+    const stopSync = () => {
+      if (!syncing) return;
+      gsap.ticker.remove(sync);
+      syncing = false;
+    };
+
+    const magnify = (element: HTMLElement) => {
+      target = element;
+      const rect = element.getBoundingClientRect();
+
+      content.replaceChildren();
+      clone = rect.width * rect.height <= MAX_CLONE_AREA ? buildClone(element) : null;
+      if (clone) content.appendChild(clone);
+
+      lens.classList.add("is-magnifying");
+      gsap.killTweensOf(lensState);
+      gsap.to(lensState, {
+        size: LENS_SIZE,
+        magnification: MAGNIFICATION,
+        duration: reduceMotion ? 0.2 : 0.55,
+        ease: reduceMotion ? "power2.out" : "elastic.out(1, 0.72)",
+      });
+      gsap.to(dot, {opacity: 0, scale: 0.4, duration: 0.25, ease: "power2.out"});
+      startSync();
+      sync();
+    };
+
+    const release = () => {
+      target = null;
+      lens.classList.remove("is-magnifying");
+      gsap.killTweensOf(lensState);
+      gsap.to(lensState, {
+        size: IDLE_SIZE,
+        magnification: 1,
+        duration: reduceMotion ? 0.15 : 0.35,
+        ease: "power3.out",
+        onComplete: () => {
+          content.replaceChildren();
+          clone = null;
+          stopSync();
+        },
+      });
+      gsap.to(dot, {opacity: 1, scale: 1, duration: 0.25, ease: "power2.out"});
+    };
 
     const onMove = (e: MouseEvent) => {
-      moveDot(e.clientX);
+      moveDotX(e.clientX);
       moveDotY(e.clientY);
-      moveRing(e.clientX);
-      moveRingY(e.clientY);
+      moveLensX(e.clientX);
+      moveLensY(e.clientY);
     };
 
     const onOver = (e: MouseEvent) => {
-      const target = (e.target as HTMLElement)?.closest("a, button, [data-fs-hover]");
-      if (target) gsap.to(ring, {scale: 1.8, duration: 0.3});
+      const next = (e.target as HTMLElement | null)?.closest<HTMLElement>(HOVER_SELECTOR) ?? null;
+      if (next === target) return;
+      if (next) magnify(next);
+      else release();
     };
 
-    const onOut = (e: MouseEvent) => {
-      const target = (e.target as HTMLElement)?.closest("a, button, [data-fs-hover]");
-      if (target) gsap.to(ring, {scale: 1, duration: 0.3});
+    const onLeave = () => {
+      if (target) release();
     };
 
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseover", onOver);
-    document.addEventListener("mouseout", onOut);
+    document.addEventListener("mouseleave", onLeave);
     document.body.classList.add("fs-cursor-active");
 
     return () => {
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseover", onOver);
-      document.removeEventListener("mouseout", onOut);
+      document.removeEventListener("mouseleave", onLeave);
       document.body.classList.remove("fs-cursor-active");
+      gsap.killTweensOf([lensState, dot, lens]);
+      stopSync();
+      content.replaceChildren();
     };
-  }, [dotRef, ringRef]);
+  }, [dotRef, lensRef, contentRef]);
 };


### PR DESCRIPTION
## What changed

The animated cursor is now a water drop that deforms with its own movement, swells into a magnifying lens when it approaches an interactive element instead of just scaling its ring up, and rides above everything else on the page.

### Droplet physics

- Velocity is measured from the **drop's own animated position**, not from the raw pointer, so the deformation belongs to the drop rather than to the mouse.
- A spring (stiffness 210, damping 15) stretches the drop along its heading and squeezes it across, keeping the volume believable, and lets it **wobble back into a bead** when it settles instead of snapping back.
- The trailing edge sharpens into a tail (`border-radius` 50% → 20%) in proportion to speed, and the heading is approached the short way around so 350° → 10° does not spin backwards.

### Magnifier

- On hover the hovered element is cloned into the drop and scaled 1.75x, with the point under the lens centre pinned, so the magnified copy matches what the glass is actually sitting on. It is re-synced every frame, so it tracks scrolling and layout changes too.
- The clone and the specular are **counter-rotated** against the drop. What survives the composition is `rotate(a)·scale(sx,sy)·rotate(-a)` — the content stays world-upright with the light fixed, and the only visible effect is a directional smear while the drop travels. The focus point sits on the rotation origin, so the lens stays aligned throughout.
- Stretch is capped lower while magnifying (0.16 vs 0.34) so the magnified text does not distort too far.

### Staying on top

`Modal` is a native `dialog` element opened with `showModal()`, which paints in the **top layer** — a layer where z-index does not apply at all, so no value would have kept the drop visible over it.

- Both cursor layers are rendered straight into `document.body` through a portal, so no nested stacking context can trap them, and their z-index is raised for the overlays that do play by z-index rules (e.g. the Radix dropdowns at `z-50`).
- They are promoted into the top layer as manual popovers. The top layer is ordered by promotion rather than by z-index, so a `MutationObserver` re-promotes the drop whenever a `dialog[open]` or another popover joins — otherwise a modal opened later would cover it again.
- A small `.fs-cursor-layer` reset undoes the parts of the UA popover box the cursor styles do not already replace (`inset`, `margin`, `padding`, `border`), which would otherwise re-centre the drop and put a border on the dot. It sits above `.fs-lens` so the glass keeps its own border.

### Continuous glass

Glass strength, rim shine and tail sharpness are custom properties written per frame (`--fs-glass`, `--fs-shine`, `--fs-drop-tail`) feeding `calc()` inside `backdrop-filter` and the shadow alphas. At rest it is a subtle water bead (blur 1px, brightness 1.12); approaching a target it melts into the lens (blur 6px, darkened for contrast) on the same elastic tween — no state switch.

## Notes

- Targets are still `a, button, [data-fs-hover]`.
- Elements larger than ~1.4M px² get the glass but no magnified copy, to avoid cloning very large subtrees.
- The clone is `aria-hidden`, stripped of `id`s, and has animations/transitions/backdrop filters disabled so it cannot duplicate ids or re-run entrance animations.
- Browsers without the popover API ignore the attribute and fall back to plain z-index stacking.
- `prefers-reduced-motion` disables the droplet deformation and the travelling sheen and shortens the tweens; the effect is still pointer-fine only.
- Cleanup releases the lens, disconnects the observer and removes the clone on unmount, and the lens releases itself if the hovered element leaves the DOM.

## Verification

- `pnpm build` passes; `oxlint src` reports only a pre-existing warning in `src/legacy`.
- Checked in Chromium at 1440x900, against both the dev server and the production bundle:
  - Droplet: 1.00/1.00 at rest, up to 1.38/0.73 mid-flight aligned with the heading, back to 1.00/1.00 after settling; tail and heading follow horizontal and diagonal moves.
  - Magnifier: nav links, contact CTA, project cards and the `/legal` buttons all magnify aligned with the pointer, upright and crisp once settled.
  - Modals: with a project dialog open, both layers report `:popover-open`, sit directly under the document body, and the drop renders over the dialog — at rest and magnifying a link inside the modal. The dot keeps its 6px size with no UA border or padding.
  - Rapid switching between adjacent targets leaves exactly one clone; leaving all targets restores the 30px bead and removes the clone.