### PR TITLE
feat(auth): host the OAuth sign-in screen at /apps/auth

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,7 +1,9 @@
 # Auth interface
 
-The screens under `/auth` are the front-end of [`franciscosolis-auth`](https://api.franciscosolis.cl/auth/openapi.json),
-the centralized auth service for franciscosolis.cl and its services.
+The screens under `/auth`, plus the hosted sign-in screen at `/apps/auth`, are the front-end of
+[`franciscosolis-auth`](https://api.franciscosolis.cl/auth/openapi.json), the centralized auth
+service for franciscosolis.cl and its services. That service is a pure API — it renders no HTML —
+so every page a user sees during a sign-in is one of these.
 
 | Route            | What it is                                                              |
 | ---------------- | ----------------------------------------------------------------------- |
@@ -9,9 +11,35 @@ the centralized auth service for franciscosolis.cl and its services.
 | `/auth/callback` | Where both providers return; redeems the authorization code             |
 | `/auth/account`  | Profile, granted access, linked providers, active sessions              |
 | `/auth/admin`    | Users, invitations, client applications, roles and permissions          |
+| `/apps/auth`     | The service's **hosted** sign-in screen — see below                      |
 
 `/auth/account` and `/auth/admin` need a session; anonymous visitors are sent to `/auth` with a
 `return_to` so the flow resumes where they were headed.
+
+## The hosted sign-in screen
+
+`api.franciscosolis.cl` is a backend end to end: it answers JSON and redirects and renders no
+pages at all. An OAuth flow has exactly one step that must face a human, and `/apps/auth` is it.
+
+The service's `GET /oauth/authorize` validates a request, parks it, and redirects the browser to
+`https://franciscosolis.cl/apps/auth?request=<handle>` (its `AUTH_LOGIN_URL`). The screen then:
+
+1. reads `GET /oauth/authorize/<handle>` for the client's name and the providers this deployment
+   actually has configured — it hardcodes none of them;
+2. posts an address to `POST /oauth/authorize/<handle>/magic-link`, or navigates to a provider's
+   `start_url`;
+3. leaves the rest to the service, which redirects back to the *client's* registered redirect URI
+   with a single-use code.
+
+This is what sets it apart from `/auth`, and why it is a separate screen rather than a mode of the
+same one. `/auth` signs **this site** in: it mints its own PKCE verifier and `state` and drives the
+flow as a client. `/apps/auth` signs in whichever application parked the request — which need not
+be one of this site's — so it holds no session, no client id and no transaction of its own. The
+handle in the query string is its entire context, and holding it grants nothing: a provider still
+has to authenticate someone, and the code still goes to the client's registered redirect URI.
+
+Its two `fetch` endpoints are cross-origin by construction; the auth service allows them from any
+origin an active client registered (`CORS_PARKED_REQUEST` in its `middleware/cors.ts`).
 
 ## How sign-in works
 
@@ -96,6 +124,8 @@ src/lib/auth/
   auth-client.ts    composes the above into one application's client
   auth-provider.tsx restores the session and keeps context in step with the token store
   useResource.ts    load-one-resource hook with abort, retry and 403 reporting
+  authorize.ts      the parked-request endpoints behind /apps/auth — no client, no session
 src/components/auth/ the sign-in and callback panels, shared by every application on this site
-src/pages/auth/      the screens, split out of the main bundle and fetched on demand
+src/pages/auth/      the screens, split out of the main bundle and fetched on demand;
+                     authorize.tsx is the hosted screen and belongs to no application here
 ```

--- a/src/lib/auth/authorize.ts
+++ b/src/lib/auth/authorize.ts
@@ -1,0 +1,34 @@
+/**
+ * The hosted authorization screen's view of the auth service.
+ *
+ * `api.franciscosolis.cl` is a backend and renders nothing, so the one step of an OAuth flow that
+ * has to face a human belongs here: its `GET /oauth/authorize` parks a validated request and sends
+ * the browser to `/apps/auth?request=<handle>`. The two calls below are the whole protocol from
+ * this side — read what the parked request is, then start one of its providers.
+ *
+ * Nothing here is tied to an `AuthClient`: the request being signed in to belongs to whichever
+ * application started it, which may not be one of this site's own. Neither endpoint is
+ * authenticated, and neither touches a session — the handle in the URL is the only credential, and
+ * holding it grants nothing on its own.
+ */
+
+import {webHttp} from "@/lib/auth/client.ts";
+import type {MagicLinkAccepted, PendingAuthorizationRequest} from "@/lib/auth/types.ts";
+
+/** Base path of the parked request, with the handle escaped for use in a URL. */
+const parked = (handle: string) => `/oauth/authorize/${encodeURIComponent(handle)}`;
+
+/** What the user is signing in to, and which providers this deployment can offer them. */
+export const loadAuthorizationRequest = (handle: string, signal?: AbortSignal) =>
+  webHttp.request<PendingAuthorizationRequest>(parked(handle), {auth: false, signal});
+
+/**
+ * Emails a sign-in link that resumes this parked request. Answers the same way whether or not the
+ * address can sign in, so this screen cannot be used to discover which addresses have an account.
+ */
+export const requestParkedMagicLink = (handle: string, email: string) =>
+  webHttp.request<MagicLinkAccepted>(`${parked(handle)}/magic-link`, {
+    auth: false,
+    method: "POST",
+    json: {email},
+  });

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -30,6 +30,40 @@ export type ServiceStatus = {
   providers: AuthProviderInfo[];
 };
 
+/* ── Parked authorization requests ────────────────────────────────────────── */
+
+/** One provider as offered for a parked request, with the URL that starts it. */
+export type PendingAuthorizationProvider = {
+  name: AuthProviderName | (string & {});
+  display_name: string;
+  /** `email` providers are started by posting an address, `redirect` ones by navigating away. */
+  initiation: "email" | "redirect" | (string & {});
+  /** Absolute URL on the auth service that resumes this request through the provider. */
+  start_url: string;
+};
+
+/**
+ * A request parked by `GET /oauth/authorize`, as the hosted sign-in screen reads it.
+ *
+ * It carries only what the browser holding the handle already sent — the client's `state` and
+ * `nonce` are deliberately not here.
+ */
+export type PendingAuthorizationRequest = {
+  request: string;
+  client_id: string;
+  client_name: string;
+  scope: string | null;
+  login_hint: string | null;
+  expires_at: string;
+  providers: PendingAuthorizationProvider[];
+};
+
+/** What both magic-link endpoints answer with, whether or not an email actually went out. */
+export type MagicLinkAccepted = {
+  message: string;
+  expires_in: number;
+};
+
 /* ── Tokens ───────────────────────────────────────────────────────────────── */
 
 /** Flat OAuth 2.0 token response — not wrapped in the `{ code, data }` envelope. */

--- a/src/pages/auth/auth-routes.tsx
+++ b/src/pages/auth/auth-routes.tsx
@@ -4,7 +4,7 @@ import type {RouteObject} from "react-router-dom";
 import {AuthLoading} from "@/components/auth/auth-loading.tsx";
 import {RequireAuth} from "@/components/auth/require-auth.tsx";
 import {NotFound} from "@/pages/not-found/not-found.tsx";
-import {Account, Admin, Callback, SignIn} from "@/pages/auth/lazy-screens.tsx";
+import {Account, Admin, Authorize, Callback, SignIn} from "@/pages/auth/lazy-screens.tsx";
 
 /** Everything under /auth: sign-in, the OAuth callback and the areas that need a session. */
 export const authRoutes: RouteObject = {
@@ -40,6 +40,33 @@ export const authRoutes: RouteObject = {
           element: <Admin/>,
         },
       ],
+    },
+    {
+      path: "*",
+      element: <NotFound/>,
+    },
+  ],
+};
+
+/**
+ * The auth service's hosted sign-in screen, at /apps/auth.
+ *
+ * Kept apart from `authRoutes` on purpose. Everything under `/auth` belongs to *this site* and
+ * signs in under its own client id; this one belongs to the auth service and signs in whichever
+ * application parked the request it was handed. It is public and stateless — the handle in the
+ * query string is the whole context — so it sits outside both the gate and any `AuthProvider`.
+ */
+export const authorizeRoutes: RouteObject = {
+  path: "apps/auth",
+  element: (
+    <Suspense fallback={<AuthLoading/>}>
+      <Outlet/>
+    </Suspense>
+  ),
+  children: [
+    {
+      index: true,
+      element: <Authorize/>,
     },
     {
       path: "*",

--- a/src/pages/auth/authorize.tsx
+++ b/src/pages/auth/authorize.tsx
@@ -1,0 +1,212 @@
+import {useCallback, useState} from "react";
+import type {FormEvent} from "react";
+import {useTranslation} from "react-i18next";
+import {Link, useSearchParams} from "react-router-dom";
+import {ArrowLeft, ArrowSquareOut, EnvelopeSimple, PaperPlaneTilt} from "@phosphor-icons/react";
+import {SiGoogle} from "@icons-pack/react-simple-icons";
+import {AuthCard} from "@/components/auth/auth-card.tsx";
+import {Alert} from "@/components/ui/alert.tsx";
+import {Button} from "@/components/ui/button/button.tsx";
+import {Field, Input} from "@/components/ui/input.tsx";
+import {Spinner} from "@/components/ui/spinner.tsx";
+import {loadAuthorizationRequest, requestParkedMagicLink} from "@/lib/auth/authorize.ts";
+import type {PendingAuthorizationProvider} from "@/lib/auth/types.ts";
+import {describeError, useResource} from "@/lib/auth/useResource.ts";
+
+/**
+ * The auth service's hosted sign-in screen, at `/apps/auth`.
+ *
+ * `api.franciscosolis.cl` is a pure backend: it validates an authorization request, parks it, and
+ * redirects here with `?request=<handle>`. This screen is the only page in the whole OAuth flow, so
+ * it belongs to whichever application started the request — not to this site. That is the one thing
+ * that sets it apart from `/auth`, which signs *this site* in and mints its own PKCE transaction:
+ * here the request already exists server-side and every provider is a URL the service handed over.
+ *
+ * It therefore hardcodes nothing about the providers. What the panel offers is what
+ * `GET /oauth/authorize/:handle` lists, which is what the deployment actually has configured.
+ */
+
+const providerIcon = (provider: PendingAuthorizationProvider, size = 16) =>
+  provider.name === "google" ? <SiGoogle size={size}/> : <ArrowSquareOut size={size}/>;
+
+type Phase = {kind: "form"} | {kind: "sent"; email: string; expiresIn: number};
+
+export const Authorize = () => {
+  const {t} = useTranslation();
+  const [params] = useSearchParams();
+  const handle = params.get("request");
+
+  const request = useResource(
+    useCallback(
+      (signal: AbortSignal) =>
+        handle ? loadAuthorizationRequest(handle, signal) : Promise.reject(new Error("missing-request")),
+      [handle],
+    ),
+  );
+
+  const [email, setEmail] = useState<string | null>(null);
+  const [phase, setPhase] = useState<Phase>({kind: "form"});
+  const [busy, setBusy] = useState<"magic_link" | "redirect" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  /* The service's `login_hint` seeds the field, but only until the user types over it. */
+  const address = email ?? request.data?.login_hint ?? "";
+
+  const submitMagicLink = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!handle) return;
+    setError(null);
+    setBusy("magic_link");
+    try {
+      const {expires_in} = await requestParkedMagicLink(handle, address.trim());
+      setPhase({kind: "sent", email: address.trim(), expiresIn: expires_in});
+    } catch (cause) {
+      setError(describeError(cause).message);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  /* A redirect provider is a plain navigation away: the service resumes the parked request itself. */
+  const startRedirectProvider = (provider: PendingAuthorizationProvider) => {
+    setError(null);
+    setBusy("redirect");
+    window.location.assign(provider.start_url);
+  };
+
+  const backHome = (
+    <Link to="/" className="text-neutral-400 underline-offset-4 transition-colors hover:text-text" data-fs-hover>
+      {t("auth:authorize.back_home")}
+    </Link>
+  );
+
+  /* Opened by hand rather than by the service: there is no request to sign in to. */
+  if (!handle) {
+    return (
+      <AuthCard title={t("auth:authorize.invalid_title")} subtitle={t("auth:authorize.invalid_subtitle")}>
+        <Alert tone="error">{t("auth:authorize.missing_request")}</Alert>
+        <p className="mt-5 text-[13px] text-neutral-500">{backHome}</p>
+      </AuthCard>
+    );
+  }
+
+  if (request.loading) {
+    return (
+      <AuthCard title={t("auth:authorize.loading_title")} subtitle={t("auth:authorize.loading_subtitle")}>
+        <div className="flex items-center gap-3 text-sm text-neutral-400">
+          <Spinner size={18} label={t("auth:authorize.loading_title")}/>
+          {t("auth:authorize.loading_working")}
+        </div>
+      </AuthCard>
+    );
+  }
+
+  /* An unknown or expired handle. Only the application that started the flow can start a new one. */
+  if (request.error || !request.data) {
+    return (
+      <AuthCard title={t("auth:authorize.expired_title")} subtitle={t("auth:authorize.expired_subtitle")}>
+        <Alert tone="error">
+          {t(`auth:errors.${request.error}`, {defaultValue: request.error ?? t("auth:authorize.expired_subtitle")})}
+        </Alert>
+        <p className="mt-5 text-[13px] text-neutral-500">{backHome}</p>
+      </AuthCard>
+    );
+  }
+
+  const pending = request.data;
+  const eyebrow = t("auth:authorize.eyebrow");
+  const emailProviders = pending.providers.filter((provider) => provider.initiation === "email");
+  const redirectProviders = pending.providers.filter((provider) => provider.initiation === "redirect");
+
+  if (phase.kind === "sent") {
+    return (
+      <AuthCard
+        title={t("auth:sign_in.sent_title")}
+        subtitle={t("auth:sign_in.sent_subtitle", {email: phase.email})}
+        eyebrow={eyebrow}
+      >
+        <div className="flex flex-col gap-5">
+          <Alert tone="success" title={t("auth:sign_in.sent_alert_title")}>
+            {t("auth:sign_in.sent_expiry", {minutes: Math.max(1, Math.round(phase.expiresIn / 60))})}
+          </Alert>
+          <p className="text-[13px] leading-relaxed text-neutral-400">{t("auth:authorize.sent_note")}</p>
+          <Button variant="secondary" onClick={() => setPhase({kind: "form"})} data-fs-hover>
+            <ArrowLeft size={16}/> {t("auth:sign_in.use_another")}
+          </Button>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      title={t("auth:authorize.title")}
+      subtitle={t("auth:authorize.subtitle", {application: pending.client_name})}
+      eyebrow={eyebrow}
+      footer={
+        <>
+          {t("auth:sign_in.invite_only")} {backHome}
+        </>
+      }
+    >
+      <div className="flex flex-col gap-5">
+        {error && <Alert tone="error">{t(`auth:errors.${error}`, {defaultValue: error})}</Alert>}
+
+        {emailProviders.length > 0 && (
+          <form className="flex flex-col gap-4" onSubmit={submitMagicLink} noValidate>
+            <Field label={t("auth:sign_in.email_label")} htmlFor="authorize-email" hint={t("auth:sign_in.email_hint")}>
+              <Input
+                id="authorize-email"
+                name="email"
+                type="email"
+                required
+                autoComplete="email"
+                autoFocus
+                inputMode="email"
+                placeholder={t("auth:sign_in.email_placeholder")}
+                value={address}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </Field>
+
+            <Button type="submit" disabled={busy !== null} data-fs-hover>
+              {busy === "magic_link" ? <Spinner size={16}/> : <PaperPlaneTilt size={16}/>}
+              {t("auth:sign_in.magic_link_cta")}
+            </Button>
+          </form>
+        )}
+
+        {emailProviders.length > 0 && redirectProviders.length > 0 && (
+          <div className="flex items-center gap-3" aria-hidden>
+            <span className="h-px flex-1 bg-neutral-800"/>
+            <span className="text-[11px] tracking-[0.12em] text-neutral-600 uppercase">
+              {t("auth:sign_in.divider")}
+            </span>
+            <span className="h-px flex-1 bg-neutral-800"/>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2">
+          {redirectProviders.map((provider) => (
+            <Button
+              key={provider.name}
+              variant="secondary"
+              onClick={() => startRedirectProvider(provider)}
+              disabled={busy !== null}
+              data-fs-hover
+            >
+              {busy === "redirect" ? <Spinner size={16}/> : providerIcon(provider)}
+              {t("auth:authorize.continue_with", {provider: provider.display_name})}
+            </Button>
+          ))}
+        </div>
+
+        {pending.providers.length === 0 && <Alert tone="error">{t("auth:authorize.no_providers")}</Alert>}
+
+        <p className="flex items-center gap-2 text-[13px] text-neutral-500">
+          <EnvelopeSimple size={15}/> {t("auth:sign_in.no_password")}
+        </p>
+      </div>
+    </AuthCard>
+  );
+};

--- a/src/pages/auth/lazy-screens.tsx
+++ b/src/pages/auth/lazy-screens.tsx
@@ -7,6 +7,10 @@ import {lazy} from "react";
 
 export const SignIn = lazy(() => import("@/pages/auth/sign-in.tsx").then((module) => ({default: module.SignIn})));
 
+export const Authorize = lazy(() =>
+  import("@/pages/auth/authorize.tsx").then((module) => ({default: module.Authorize})),
+);
+
 export const Callback = lazy(() =>
   import("@/pages/auth/callback.tsx").then((module) => ({default: module.Callback})),
 );

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -4,7 +4,7 @@ import {Home} from "@/pages/home/home.tsx";
 import {Brand} from "@/pages/brand/brand.tsx";
 import {Legal} from "@/pages/legal/legal.tsx";
 import {NotFound} from "@/pages/not-found/not-found.tsx";
-import {authRoutes} from "@/pages/auth/auth-routes.tsx";
+import {authRoutes, authorizeRoutes} from "@/pages/auth/auth-routes.tsx";
 import {cmsRoutes} from "@/pages/cms/cms-routes.tsx";
 
 const routes = [
@@ -29,6 +29,8 @@ const routes = [
       },
       /* Auth — sign-in, the OAuth callback and the signed-in areas */
       authRoutes,
+      /* The auth service's hosted sign-in screen, where /oauth/authorize sends the browser */
+      authorizeRoutes,
       /* CMS — its own application, signed in under its own client id */
       cmsRoutes,
       /* 404 */

--- a/src/translations/en/auth.json
+++ b/src/translations/en/auth.json
@@ -24,6 +24,23 @@
     "sent_note": "Open the link in this browser so the sign-in can finish where it started. You can close this tab afterwards.",
     "use_another": "Use another address"
   },
+  "authorize": {
+    "eyebrow": "Authorization",
+    "title": "Sign in",
+    "subtitle": "to continue to {{application}}",
+    "continue_with": "Continue with {{provider}}",
+    "sent_note": "Open the link in this browser so the application you came from gets you back. You can close this tab afterwards.",
+    "no_providers": "This deployment has no sign-in method configured, so the request cannot be completed.",
+    "loading_title": "Preparing your sign-in",
+    "loading_subtitle": "Reading the request the application handed over.",
+    "loading_working": "One moment…",
+    "invalid_title": "Nothing to sign in to",
+    "invalid_subtitle": "This screen is opened by the auth service at the end of an application's sign-in.",
+    "missing_request": "This address carries no sign-in request. Start from the application you want to sign in to.",
+    "expired_title": "This sign-in request is no longer valid",
+    "expired_subtitle": "It may have expired, or it was already finished in another tab.",
+    "back_home": "Back to the site"
+  },
   "callback": {
     "title": "Signing you in",
     "subtitle": "Exchanging the authorization code for your session.",

--- a/src/translations/es/auth.json
+++ b/src/translations/es/auth.json
@@ -24,6 +24,23 @@
     "sent_note": "Abre el enlace en este mismo navegador para que el inicio de sesión termine donde empezó. Después puedes cerrar esta pestaña.",
     "use_another": "Usar otra dirección"
   },
+  "authorize": {
+    "eyebrow": "Autorización",
+    "title": "Inicia sesión",
+    "subtitle": "para continuar en {{application}}",
+    "continue_with": "Continuar con {{provider}}",
+    "sent_note": "Abre el enlace en este mismo navegador para que la aplicación de origen te reciba de vuelta. Después puedes cerrar esta pestaña.",
+    "no_providers": "Este despliegue no tiene ningún método de inicio de sesión configurado, así que la solicitud no se puede completar.",
+    "loading_title": "Preparando tu inicio de sesión",
+    "loading_subtitle": "Leyendo la solicitud que entregó la aplicación.",
+    "loading_working": "Un momento…",
+    "invalid_title": "No hay nada que autorizar",
+    "invalid_subtitle": "Esta pantalla la abre el servicio de autenticación al final del inicio de sesión de una aplicación.",
+    "missing_request": "Esta dirección no trae ninguna solicitud de inicio de sesión. Empieza desde la aplicación en la que quieres entrar.",
+    "expired_title": "Esta solicitud de inicio de sesión ya no es válida",
+    "expired_subtitle": "Puede que haya caducado o que ya se haya completado en otra pestaña.",
+    "back_home": "Volver al sitio"
+  },
   "callback": {
     "title": "Iniciando tu sesión",
     "subtitle": "Canjeando el código de autorización por tu sesión.",


### PR DESCRIPTION
The auth service behind `api.franciscosolis.cl` is becoming a pure API that renders no HTML. An OAuth flow has exactly one step that must face a human, so that step moves here.

Companion PR: [`Im-Fran/api.franciscosolis.cl#13` — stop rendering HTML, delegate sign-in to the front-end](https://github.com/Im-Fran/api.franciscosolis.cl/pull/13). They ship together — that PR points `AUTH_LOGIN_URL` at this screen.

## What this adds

`GET /oauth/authorize` on the service validates a request, parks it, and redirects the browser to `https://franciscosolis.cl/apps/auth?request=:handle`. The new screen answers:

1. reads `GET /oauth/authorize/:handle` for the client's name and the providers the deployment actually has configured — it hardcodes none of them, so a provider added server-side shows up here with no change;
2. posts an address to `POST /oauth/authorize/:handle/magic-link`, or navigates to a provider's `start_url`;
3. leaves the rest to the service, which redirects back to the *client's* registered redirect URI with a single-use code.

## Why it is separate from `/auth`

`/auth` signs **this site** in: it mints its own PKCE verifier and `state` and drives the flow as a client. `/apps/auth` signs in whichever application parked the request, which need not be one of this site's — so it holds no session, no client id and no transaction of its own. The handle in the query string is its entire context, and holding it grants nothing: a provider still has to authenticate someone, and the code still goes to the client's registered redirect URI.

That is also why it sits outside `RequireAuth` and outside any `AuthProvider`, and why `src/lib/auth/authorize.ts` talks to the two parked-request endpoints directly rather than going through an `AuthClient`.

## Files

- `src/lib/auth/authorize.ts` — the two parked-request calls.
- `src/pages/auth/authorize.tsx` — the screen, covering all four states the service can put it in: the pending request, the link sent, an unknown or expired handle, and being opened with no request at all.
- `src/pages/auth/auth-routes.tsx` — `authorizeRoutes` at `apps/auth`, wired into `src/router.tsx`.
- `src/lib/auth/types.ts`, `src/translations/{en,es}/auth.json`, `docs/AUTH.md`.

It reuses `AuthCard`, `Alert`, `Field`/`Input`, `Button` and `Spinner`, so it reads as part of the site rather than as a bolted-on identity provider page.

## Testing

- `pnpm run build` (`tsc -b && vite build`) clean; `oxlint src/` reports only the one pre-existing warning in `src/legacy/`.
- Driven end to end in a browser against a stub of the auth API: the pending request renders with the client's name and a prefilled `login_hint`, submitting the address reaches the sent state, an expired handle surfaces the service's own message, and opening `/apps/auth` with no `request` parameter explains itself instead of hanging.

Note unrelated to this change: `pnpm run lint` is broken on `dev` — the script still calls `eslint`, but the config was removed when the repo moved to `oxlint`. Left alone here.