### PR TITLE
auth: unbreak CMS sign-in and harden the flow around it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,21 @@ VITE_AUTH_BASE_URL=https://api.franciscosolis.cl/auth
 # http://localhost:5173/auth/callback.
 VITE_AUTH_CLIENT_ID=franciscosolis-web
 
+# Redirect URI path the site asks the auth service to return the browser to. Only set this when the
+# application is registered under a path other than the callback route itself; the landing is
+# forwarded to /auth/callback either way.
+# VITE_AUTH_REDIRECT_PATH=/auth/callback
+
 # CMS service the /cms interface reads from. Defaults to the production one when unset.
 VITE_CMS_BASE_URL=https://api.franciscosolis.cl/cms
 
-# Client ID the CMS is registered under. It is a separate application, so it needs its own entry on
-# the auth service with <origin>/cms/callback among its redirect URIs — for local work that is
-# http://localhost:5173/cms/callback.
+# Client ID the CMS is registered under. It is a separate application with its own entry on the
+# auth service.
 VITE_CMS_CLIENT_ID=franciscosolis-cms
+
+# Redirect URI path the CMS asks for. It defaults to the pre-move /apps/cms/callback, because that
+# is what the application is still registered under — <origin>/cms/callback is refused with
+# "redirect_uri is not registered for this client". The landing is forwarded to /cms/callback with
+# the code and state intact. Once <origin>/cms/callback is registered under Admin → Applications,
+# set this to /cms/callback and the extra hop disappears.
+# VITE_CMS_REDIRECT_PATH=/cms/callback

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -87,10 +87,15 @@ the usual cost of a browser-only public client with no back-end of its own to ho
 Both values are build-time env vars (see `.env.example`), so a preview deployment can point at
 another issuer or register under its own client id without a code change:
 
-| Variable               | Default                             |
-| ---------------------- | ----------------------------------- |
-| `VITE_AUTH_BASE_URL`   | `https://api.franciscosolis.cl/auth` |
-| `VITE_AUTH_CLIENT_ID`  | `franciscosolis-web`                 |
+| Variable                  | Default                              |
+| ------------------------- | ------------------------------------ |
+| `VITE_AUTH_BASE_URL`      | `https://api.franciscosolis.cl/auth` |
+| `VITE_AUTH_CLIENT_ID`     | `franciscosolis-web`                 |
+| `VITE_AUTH_REDIRECT_PATH` | `/auth/callback`                     |
+
+`VITE_AUTH_REDIRECT_PATH` exists for the case the CMS is in today: an application registered under a
+path the interface has since moved away from. Point it at the registered path and let `router.tsx`
+forward that landing to the callback route, rather than moving the route to match the registration.
 
 Each application registers separately; the CMS's own entry is documented in [CMS.md](./CMS.md).
 

--- a/docs/CMS.md
+++ b/docs/CMS.md
@@ -27,8 +27,10 @@ Everything except `sign-in` and `callback` needs a session; anonymous visitors a
 outside `/cms` is dropped.
 
 The interface used to live at `/apps/cms`. That path still resolves — `router.tsx` forwards the whole
-sub-path, query string included, so old links and the previously registered redirect URI keep
-working until the application is re-registered.
+sub-path, query string included — and the sign-in flow depends on it: the application is still
+registered under `<origin>/apps/cms/callback`, so that is the redirect URI the CMS asks for and the
+path the service returns the browser to. The forward carries the `code` and `state` on to
+`/cms/callback`, which redeems them. See *A client application of its own* below.
 
 ## A client application of its own
 
@@ -37,8 +39,21 @@ The CMS signs in at the same issuer as the rest of the site, but under its own c
 | | Site | CMS |
 | --- | --- | --- |
 | Client id | `franciscosolis-web` | `franciscosolis-cms` |
-| Redirect URI | `<origin>/auth/callback` | `<origin>/cms/callback` |
+| Redirect URI (registered) | `<origin>/auth/callback` | `<origin>/apps/cms/callback` |
+| Callback route (in the app) | `/auth/callback` | `/cms/callback` |
 | Storage namespace | `fs.auth.*` | `fs.cms.*` |
+
+The CMS's two rows differ because the application was never re-registered after the interface moved
+off `/apps/cms`, and the authorization server matches redirect URIs by exact string: asking for
+`<origin>/cms/callback` is refused with `400 redirect_uri is not registered for this client` at
+every entry point — magic link, Google and `/oauth/authorize` alike — *before* any redirect this
+site could forward. `CMS_REDIRECT_PATH` in `src/lib/cms/config.ts` therefore quotes the registered
+path, and `redirectUri()` derives the value from that config rather than from the address bar, so
+the token exchange quotes the same string the flow started with, as RFC 6749 §4.1.3 requires.
+
+To retire the extra hop: add `<origin>/cms/callback` to the application's redirect URIs under
+**Admin → Applications**, then set `VITE_CMS_REDIRECT_PATH=/cms/callback` (or change the default in
+`src/lib/cms/config.ts`). Do not remove the old URI until every deployment has been rebuilt.
 
 That is what makes the access token come back minted **for the CMS**, carrying the roles the account
 holds in this application — which is exactly what `/cms/admin/*` checks. It also means the two
@@ -114,18 +129,22 @@ page to the API is its own change.
 
 ## Configuration
 
-| Variable             | Default                             |
-| -------------------- | ----------------------------------- |
-| `VITE_CMS_BASE_URL`  | `https://api.franciscosolis.cl/cms` |
-| `VITE_CMS_CLIENT_ID` | `franciscosolis-cms`                |
+| Variable                 | Default                             |
+| ------------------------ | ----------------------------------- |
+| `VITE_CMS_BASE_URL`      | `https://api.franciscosolis.cl/cms` |
+| `VITE_CMS_CLIENT_ID`     | `franciscosolis-cms`                |
+| `VITE_CMS_REDIRECT_PATH` | `/apps/cms/callback`                |
 
 The application has to exist on the auth service with this site's CMS callback among its redirect
-URIs — `https://franciscosolis.cl/cms/callback` in production, `http://localhost:5173/cms/callback`
-for local work. Register it from **Admin → Applications** in the auth interface (leave *Confidential*
-off; a browser client cannot keep a secret), then grant the editor accounts a role scoped to it.
+URIs. What is registered today is `https://franciscosolis.cl/apps/cms/callback` in production and
+`http://localhost:5173/apps/cms/callback` for local work — the pre-move paths, which is why
+`VITE_CMS_REDIRECT_PATH` defaults to the legacy one. Register from **Admin → Applications** in the
+auth interface (leave *Confidential* off; a browser client cannot keep a secret), then grant the
+editor accounts a role scoped to it.
 
-Note that the API answers CORS for `https://franciscosolis.cl` only, so a dev server on
-`localhost:5173` needs the origin allowed on the service before the CMS can talk to it.
+The auth API answers CORS for an exact allowlist — `https://franciscosolis.cl` and
+`http://localhost:5173` — so a dev server on the default Vite port can talk to it as is. A dev
+server on any other port needs its origin added on the service first.
 
 ## Layout of the code
 

--- a/index.html
+++ b/index.html
@@ -87,7 +87,29 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-3G7Q5ZRSDZ');
+      /*
+       * Analytics never sees the sign-in query string.
+       *
+       * By default gtag reports the full address, and on the auth screens that address is the
+       * secret: `/apps/auth?request=<handle>` is a bearer credential anyone holding it can read
+       * for the life of the parked request — along with the `login_hint` inside it, which is the
+       * signing-in person's email. `code`, `state` and `token` are the same kind of value on the
+       * callbacks. They are stripped before the page_view rather than the page being exempted,
+       * so the visit is still counted, just without the credential attached.
+       */
+      gtag('config', 'G-3G7Q5ZRSDZ', {
+        page_location: (function () {
+          try {
+            var url = new URL(window.location.href);
+            ['request', 'code', 'state', 'token', 'login_hint', 'error_description'].forEach(function (key) {
+              url.searchParams.delete(key);
+            });
+            return url.toString();
+          } catch (error) {
+            return window.location.origin + window.location.pathname;
+          }
+        })(),
+      });
     </script>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "brand:icons": "node scripts/generate-brand-icons.mjs",
-    "lint": "eslint .",
+    "lint": "oxlint",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,27 @@
+# Response headers Cloudflare adds to the static assets. Workers Assets reads this file from the
+# root of the deployed directory; Vite copies everything in `public/` there verbatim.
+
+/*
+  # The site never needs to sniff a type it did not declare.
+  X-Content-Type-Options: nosniff
+  # Cross-origin navigations carry the origin, never the path — a `?request=` handle or an
+  # authorization `code` must not travel in a Referer to the identity provider.
+  Referrer-Policy: strict-origin-when-cross-origin
+
+# The screens that hold a session, or the credential that leads to one. Framing any of these is
+# clickjacking with nothing to gain otherwise: nothing embeds the sign-in screen or the CMS.
+/auth
+  X-Frame-Options: DENY
+  Content-Security-Policy: frame-ancestors 'none'
+/auth/*
+  X-Frame-Options: DENY
+  Content-Security-Policy: frame-ancestors 'none'
+/cms
+  X-Frame-Options: DENY
+  Content-Security-Policy: frame-ancestors 'none'
+/cms/*
+  X-Frame-Options: DENY
+  Content-Security-Policy: frame-ancestors 'none'
+/apps/*
+  X-Frame-Options: DENY
+  Content-Security-Policy: frame-ancestors 'none'

--- a/src/components/auth/sign-in-panel.tsx
+++ b/src/components/auth/sign-in-panel.tsx
@@ -9,6 +9,7 @@ import {Button} from "@/components/ui/button/button.tsx";
 import {Field, Input} from "@/components/ui/input.tsx";
 import {Spinner} from "@/components/ui/spinner.tsx";
 import type {AuthClient} from "@/lib/auth/auth-client.ts";
+import {looksLikeEmail} from "@/lib/auth/format.ts";
 import {describeError, useResource} from "@/lib/auth/useResource.ts";
 
 type Phase = {kind: "form"} | {kind: "sent"; email: string; expiresIn: number};
@@ -52,10 +53,16 @@ export const SignInPanel = ({ns, client, returnTo, eyebrow, footer}: SignInPanel
   const submitMagicLink = async (event: FormEvent) => {
     event.preventDefault();
     setError(null);
+
+    /* Caught here rather than at the service, which answers a validation array this screen would
+       otherwise render as a bare status line. */
+    const address = email.trim();
+    if (!looksLikeEmail(address)) return setError("invalid-email");
+
     setBusy("magic_link");
     try {
-      const {expires_in} = await client.flow.startMagicLink(email.trim(), returnTo);
-      setPhase({kind: "sent", email: email.trim(), expiresIn: expires_in});
+      const {expires_in} = await client.flow.startMagicLink(address, returnTo);
+      setPhase({kind: "sent", email: address, expiresIn: expires_in});
     } catch (cause) {
       setError(describeError(cause).message);
     } finally {

--- a/src/lib/auth/auth-provider.tsx
+++ b/src/lib/auth/auth-provider.tsx
@@ -4,7 +4,7 @@ import {webAuth} from "@/lib/auth/auth-client.ts";
 import type {AuthClient} from "@/lib/auth/auth-client.ts";
 import {AuthContext, hasAdminAccess} from "@/lib/auth/auth-context.ts";
 import type {AuthStatus} from "@/lib/auth/auth-context.ts";
-import {AuthNetworkError} from "@/lib/auth/client.ts";
+import {AuthApiError, AuthNetworkError} from "@/lib/auth/client.ts";
 import type {MeResponse} from "@/lib/auth/types.ts";
 
 /**
@@ -33,13 +33,20 @@ export const AuthProvider = ({client = webAuth, children}: {client?: AuthClient;
       setError(null);
       setStatus("authenticated");
     } catch (cause) {
-      if (cause instanceof AuthNetworkError) {
-        /* The tokens may still be good; report the fault instead of signing the user out. */
-        setError("network");
+      /*
+       * Only a rejection tells us the session is over. A service that could not be reached, or one
+       * that answered 5xx or with a body that would not parse, says nothing about whether these
+       * tokens are still good — so the fault is reported and the session kept, rather than showing
+       * a sign-in form for what is a server-side hiccup and inviting a magic link nobody needed.
+       */
+      const faulted = cause instanceof AuthNetworkError || (cause instanceof AuthApiError && cause.status >= 500);
+      if (faulted) {
+        setError(cause instanceof AuthNetworkError ? "network" : "unexpected");
         setStatus(client.session.getTokens() ? "authenticated" : "anonymous");
         return;
       }
       setMe(null);
+      setError(null);
       setStatus("anonymous");
     }
   }, [client]);

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -33,14 +33,59 @@ export type RequestOptions = {
 
 export type RequestFn = <T>(path: string, options?: RequestOptions) => Promise<T>;
 
+/** How long a read may take before it counts as unreachable. Generous: this is a stall, not a SLA. */
+const REQUEST_TIMEOUT_MS = 20_000;
+
+/**
+ * The human-readable half of an error body, whichever of the three shapes it arrives in.
+ *
+ * The API answers `{ error }` with a plain string for its own rejections, but the OAuth endpoints
+ * follow RFC 6749 and put the sentence in `error_description` beside a machine code in `error`,
+ * and a schema failure answers with an *array* of issues. Reading only the string case turned the
+ * first into a bare `invalid_grant` and the other two into `Bad Request` — the service had said
+ * "A valid email address is required" and the screen showed `HTTP 400`.
+ */
+const messageFrom = (body: Partial<ApiErrorBody>): string | null => {
+  if (typeof body?.error_description === "string" && body.error_description) return body.error_description;
+
+  const {error} = body ?? {};
+  if (typeof error === "string" && error) return error;
+
+  if (Array.isArray(error)) {
+    const issues = error
+      .map((issue) => (typeof issue === "string" ? issue : issue?.message))
+      .filter((issue): issue is string => typeof issue === "string" && issue.length > 0);
+    if (issues.length > 0) return [...new Set(issues)].join(" ");
+  }
+
+  return typeof body?.message === "string" && body.message ? body.message : null;
+};
+
 const parseError = async (response: Response) => {
   try {
-    const body = (await response.json()) as Partial<ApiErrorBody>;
-    if (typeof body?.error === "string") return body.error;
+    return messageFrom((await response.json()) as Partial<ApiErrorBody>) ?? fallbackMessage(response);
   } catch {
     /* Empty or non-JSON error bodies fall back to the status text. */
+    return fallbackMessage(response);
   }
-  return response.statusText || `HTTP ${response.status}`;
+};
+
+const fallbackMessage = (response: Response) => response.statusText || `HTTP ${response.status}`;
+
+/**
+ * Reads a body the service said was JSON.
+ *
+ * A truncated or rewritten payload — a proxy that timed out mid-stream, a captive portal — is a
+ * fault of the hop, not of the session, so it is reported as one instead of letting V8's
+ * `SyntaxError` walk up into an alert box reading "Expected ',' or '}' at position 29". 502 is
+ * both accurate and what the layers above already read as "keep the session, show the fault".
+ */
+const parseJson = <T>(text: string): T => {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new AuthApiError(502, "malformed-response");
+  }
 };
 
 export type HttpClient = ReturnType<typeof createHttpClient>;
@@ -57,15 +102,33 @@ export const createHttpClient = (baseUrl: string, session: SessionStore) => {
     if (options.json !== undefined) headers["Content-Type"] = "application/json";
     if (token) headers.Authorization = `Bearer ${token}`;
 
+    const method = options.method ?? "GET";
+    /*
+     * A deadline, so a service that accepts the connection and then never answers reads as a
+     * failure rather than as a spinner that never resolves — that is what left "Restoring your
+     * session…" on screen for as long as the service cared to take.
+     *
+     * Reads only. Aborting a write mid-flight tells the caller nothing about whether it landed,
+     * and a half-known write is worse than a slow one.
+     */
+    const deadline = method === "GET" ? AbortSignal.timeout(REQUEST_TIMEOUT_MS) : null;
+    const signal =
+      deadline && options.signal ? AbortSignal.any([options.signal, deadline]) : (deadline ?? options.signal);
+
     try {
       return await fetch(`${baseUrl}${path}`, {
-        method: options.method ?? "GET",
+        method,
         headers,
         body: options.json === undefined ? undefined : JSON.stringify(options.json),
-        signal: options.signal,
+        signal,
       });
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") throw error;
+      /* The caller's own abort — an unmount, or changed inputs — is not a fault to report. */
+      if (options.signal?.aborted) throw error;
+      if (error instanceof DOMException && error.name === "TimeoutError") throw new AuthNetworkError();
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw deadline?.aborted ? new AuthNetworkError() : error;
+      }
       throw new AuthNetworkError();
     }
   };
@@ -100,7 +163,7 @@ export const createHttpClient = (baseUrl: string, session: SessionStore) => {
     const text = response.status === 204 ? "" : await response.text();
     if (!text) return undefined as T;
 
-    const body = JSON.parse(text) as ApiEnvelope<T> | T;
+    const body = parseJson<ApiEnvelope<T> | T>(text);
     return body && typeof body === "object" && "code" in body && "data" in body
       ? (body as ApiEnvelope<T>).data
       : (body as T);
@@ -119,7 +182,7 @@ export const createHttpClient = (baseUrl: string, session: SessionStore) => {
       throw new AuthNetworkError();
     }
     if (!response.ok) throw new AuthApiError(response.status, await parseError(response));
-    return (await response.json()) as T;
+    return parseJson<T>(await response.text());
   };
 
   return {request, postForm};

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -32,8 +32,16 @@ export type AuthClientConfig = {
   scope: string;
   /** Where the guard sends anonymous visitors. */
   signInRoute: string;
-  /** Route that redeems the authorization code; also the registered redirect URI. */
+  /** Route that redeems the authorization code. */
   callbackRoute: string;
+  /**
+   * Path the authorization server sends the browser back to, when it is not `callbackRoute`
+   * itself. The two only differ while an application is registered under a path the interface has
+   * since moved away from: the service redirects to the registered path, the site forwards that
+   * landing — query string intact — to the route that actually redeems the code, and the exchange
+   * still quotes the registered value, as RFC 6749 §4.1.3 requires it to.
+   */
+  redirectPath?: string;
   /** Where a sign-in lands when it did not start from a particular page. */
   defaultReturnTo: string;
   /**
@@ -55,6 +63,13 @@ export const ADMIN_ROUTE = `${AUTH_ROUTE}/admin`;
  */
 export const AUTH_CLIENT_ID = import.meta.env.VITE_AUTH_CLIENT_ID ?? "franciscosolis-web";
 
+/**
+ * Path the site is registered under, when it is not `/auth/callback`. A deployment that has to
+ * answer on a path the service knows by another name sets `VITE_AUTH_REDIRECT_PATH` rather than
+ * moving the route.
+ */
+export const AUTH_REDIRECT_PATH = import.meta.env.VITE_AUTH_REDIRECT_PATH ?? CALLBACK_ROUTE;
+
 /** The site's own client — the one `/auth` signs in with. */
 export const WEB_AUTH_CONFIG: AuthClientConfig = {
   storageNamespace: "fs.auth",
@@ -63,36 +78,59 @@ export const WEB_AUTH_CONFIG: AuthClientConfig = {
   scope: AUTH_SCOPE,
   signInRoute: AUTH_ROUTE,
   callbackRoute: CALLBACK_ROUTE,
+  redirectPath: AUTH_REDIRECT_PATH,
   defaultReturnTo: ACCOUNT_ROUTE,
 };
 
 export const authUrl = (path: string) => `${AUTH_BASE_URL}${path}`;
 
-/** Absolute redirect URI handed to the authorization server; must match the registered one. */
+/**
+ * Absolute redirect URI handed to the authorization server; must match the registered one.
+ *
+ * Derived from the configured path rather than from where the browser happens to be, so the value
+ * quoted when the code is redeemed is the same one the flow started with.
+ */
 export const redirectUri = (config: AuthClientConfig = WEB_AUTH_CONFIG) =>
-  new URL(config.callbackRoute, window.location.origin).toString();
+  new URL(config.redirectPath ?? config.callbackRoute, window.location.origin).toString();
 
 /** Absolute sign-in URL, used as the `login_url` of an emailed invitation. */
 export const loginUrl = () => new URL(AUTH_ROUTE, window.location.origin).toString();
 
 /**
  * Keeps `?return_to=` to paths inside this site — and, when the client asks for it, inside its own
- * section. A protocol-relative or absolute value would turn the sign-in screen into an open
- * redirect, so anything but a single-slash path is discarded.
+ * section. An absolute or protocol-relative value would turn the sign-in screen into an open
+ * redirect, so the value is resolved against this origin and kept only if it stayed here.
+ *
+ * Resolving rather than pattern-matching is the point: a leading-slash test looks safe and is not.
+ * The URL parser treats a backslash as a slash in an http(s) URL and strips tab, CR and LF before
+ * parsing, so `/\evil.com` and `/<tab>//evil.com` — the latter arriving decoded from
+ * `?return_to=/%09//evil.com` — both name another host while passing every string check. Handing
+ * the same parse the browser would perform is what closes that gap.
  */
 export const sanitizeReturnTo = (
   value: string | null | undefined,
   config: AuthClientConfig = WEB_AUTH_CONFIG,
 ) => {
-  if (!value || !value.startsWith("/") || value.startsWith("//")) return config.defaultReturnTo;
+  if (!value || !value.startsWith("/")) return config.defaultReturnTo;
+
+  let resolved: URL;
+  try {
+    resolved = new URL(value, window.location.origin);
+  } catch {
+    return config.defaultReturnTo;
+  }
+  if (resolved.origin !== window.location.origin) return config.defaultReturnTo;
+
+  /* Re-serialized from the parse, so what is checked below is what the router will be handed. */
+  const path = `${resolved.pathname}${resolved.search}${resolved.hash}`;
 
   if (config.returnToPrefix) {
     /* Compare on segment boundaries, so `/cms-something` is not read as being inside the CMS. */
-    const rest = value.startsWith(config.returnToPrefix) ? value.slice(config.returnToPrefix.length) : null;
+    const rest = path.startsWith(config.returnToPrefix) ? path.slice(config.returnToPrefix.length) : null;
     if (rest === null || (rest !== "" && !rest.startsWith("/") && !rest.startsWith("?"))) {
       return config.defaultReturnTo;
     }
   }
 
-  return value;
+  return path;
 };

--- a/src/lib/auth/flow.ts
+++ b/src/lib/auth/flow.ts
@@ -37,19 +37,25 @@ export const createAuthFlow = (
   /** Sends the magic link. Answers 202 whether or not the address has an account, by design. */
   const startMagicLink = async (email: string, returnTo = config.defaultReturnTo) => {
     const {transaction, codeChallenge} = await beginTransaction("magic_link", returnTo);
-    return http.request<{message: string; expires_in: number}>("/magic-link", {
-      auth: false,
-      method: "POST",
-      json: {
-        email,
-        client_id: config.clientId,
-        redirect_uri: redirectUri(config),
-        state: transaction.state,
-        code_challenge: codeChallenge,
-        code_challenge_method: "S256",
-        scope: config.scope,
-      },
-    });
+    try {
+      return await http.request<{message: string; expires_in: number}>("/magic-link", {
+        auth: false,
+        method: "POST",
+        json: {
+          email,
+          client_id: config.clientId,
+          redirect_uri: redirectUri(config),
+          state: transaction.state,
+          code_challenge: codeChallenge,
+          code_challenge_method: "S256",
+          scope: config.scope,
+        },
+      });
+    } catch (cause) {
+      /* No link went out, so nothing will ever redeem this verifier — do not leave it lying about. */
+      storage.clearTransaction(transaction.state);
+      throw cause;
+    }
   };
 
   /** Hands the browser over to Google; the flow resumes at the callback route. */
@@ -75,9 +81,15 @@ export const createAuthFlow = (
   const exchanges = new Map<string, Promise<string>>();
 
   const exchange = async (code: string, state: string) => {
-    const transaction = storage.readTransaction();
-    if (!transaction) throw new AuthApiError(400, "missing-transaction");
-    if (transaction.state !== state) throw new AuthApiError(400, "state-mismatch");
+    /*
+     * Looked up by `state` rather than "the last one started": the user may well have several
+     * links in flight — a second address, a second tab — and every one of them has to stay
+     * redeemable. A `state` no pending transaction claims is the genuine mismatch.
+     */
+    const transaction = storage.readTransaction(state);
+    if (!transaction) {
+      throw new AuthApiError(400, storage.readTransactions().length === 0 ? "missing-transaction" : "state-mismatch");
+    }
 
     const tokens = await http.postForm<TokenResponse>("/oauth/token", {
       grant_type: "authorization_code",
@@ -88,7 +100,7 @@ export const createAuthFlow = (
     });
 
     session.startSession(tokens);
-    storage.clearTransaction();
+    storage.clearTransaction(transaction.state);
     return transaction.return_to || config.defaultReturnTo;
   };
 

--- a/src/lib/auth/format.ts
+++ b/src/lib/auth/format.ts
@@ -49,3 +49,13 @@ export const initialsOf = (name: string | null | undefined, email: string) => {
   const letters = parts.length > 1 ? `${parts[0][0]}${parts[1][0]}` : source.slice(0, 2);
   return letters.toUpperCase();
 };
+
+/**
+ * Whether an address is worth sending to the service.
+ *
+ * The sign-in forms carry `noValidate` — the browser's own bubble does not match the rest of the
+ * screen — which also switches off the `type="email"` and `required` checks the markup asks for.
+ * This is what stands in for them: a deliberately loose shape test, since the only authority on
+ * whether an address exists is the mail that either arrives or does not.
+ */
+export const looksLikeEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value);

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -85,6 +85,19 @@ export const createSessionStore = (config: AuthClientConfig) => {
     }
 
     if (!response.ok) {
+      /*
+       * A refused refresh token does not on its own mean the chain is gone. Refresh tokens are
+       * single-use, so when another tab rotated this one while the request above was in flight,
+       * the service is refusing a token that is merely *spent* — and the pair that tab wrote is
+       * live. Only when the stored token is still the one just refused is the session really
+       * over; wiping unconditionally signed both tabs out of a perfectly good session.
+       */
+      const latest = storage.readTokens();
+      if (latest?.refresh_token && latest.refresh_token !== current.refresh_token) {
+        notify(latest);
+        return {status: "refreshed", tokens: latest};
+      }
+
       /* The chain is gone (rotated away, revoked or expired); there is nothing left to recover. */
       endSession();
       return {status: "revoked"};

--- a/src/lib/auth/storage.ts
+++ b/src/lib/auth/storage.ts
@@ -34,6 +34,17 @@ export type StoredTokens = {
 /** A transaction older than this is stale — a magic link the user never finished opening. */
 const TRANSACTION_TTL_MS = 30 * 60 * 1000;
 
+/**
+ * How many pending sign-ins to keep at once.
+ *
+ * One slot is not enough: a single slot means "send me another link" — or a second tab — silently
+ * overwrites the verifier the first link needs, and opening that first link then fails as a
+ * `state-mismatch`, which reads to the user as tampering rather than as the ordinary thing they
+ * just did. Each entry is a few hundred bytes and expires on its own, so remembering the recent
+ * few costs nothing and makes every link the user was actually sent redeemable.
+ */
+const MAX_TRANSACTIONS = 5;
+
 /** Refresh this long before the real expiry, so a request never travels with a just-dead token. */
 const EXPIRY_SKEW_MS = 30 * 1000;
 
@@ -54,6 +65,14 @@ const write = (key: string, value: unknown) => {
   }
 };
 
+const has = (key: string) => {
+  try {
+    return localStorage.getItem(key) !== null;
+  } catch {
+    return false;
+  }
+};
+
 const remove = (key: string) => {
   try {
     localStorage.removeItem(key);
@@ -69,27 +88,67 @@ export const createAuthStorage = (namespace: string) => {
   const tokensKey = `${namespace}.tokens`;
   const transactionKey = `${namespace}.transaction`;
 
+  /**
+   * Reads the record, expiring stale entries on the way out. A record written before this key
+   * held a list is a bare object, so it is normalized rather than discarded — an upgrade must not
+   * strand a magic link that is already in someone's inbox.
+   */
+  const readTransactions = (): AuthTransaction[] => {
+    const stored = read<AuthTransaction | AuthTransaction[]>(transactionKey);
+    if (!stored) return [];
+
+    const now = Date.now();
+    const live = (Array.isArray(stored) ? stored : [stored]).filter(
+      (transaction) => transaction?.state && now - transaction.created_at <= TRANSACTION_TTL_MS,
+    );
+
+    if (live.length === 0) remove(transactionKey);
+    return live;
+  };
+
   return {
     /** Exposed so the session store can tell its own `storage` events from another client's. */
     tokensKey,
 
-    readTokens: () => read<StoredTokens>(tokensKey),
+    readTokens: () => {
+      const tokens = read<StoredTokens>(tokensKey);
+      if (tokens && typeof tokens.access_token === "string" && tokens.access_token) return tokens;
+
+      /*
+       * Present but unusable — `{}`, `null`, unparseable, a half-written record. An object without
+       * a token is the harmful shape: it reads as "there is a session" to every guard while failing
+       * at the point of use, so each visit to a protected route flashes a loader and bounces back
+       * to sign-in, for good. Clearing whatever is there puts the browser back in a clean anonymous
+       * state instead.
+       */
+      if (has(tokensKey)) remove(tokensKey);
+      return null;
+    },
     writeTokens: (tokens: StoredTokens) => write(tokensKey, tokens),
     clearTokens: () => remove(tokensKey),
 
-    writeTransaction: (transaction: AuthTransaction) => write(transactionKey, transaction),
+    /** The live transactions, newest first, with the expired ones already dropped. */
+    readTransactions: () => readTransactions(),
 
-    readTransaction: () => {
-      const transaction = read<AuthTransaction>(transactionKey);
-      if (!transaction) return null;
-      if (Date.now() - transaction.created_at > TRANSACTION_TTL_MS) {
-        remove(transactionKey);
-        return null;
-      }
-      return transaction;
+    writeTransaction: (transaction: AuthTransaction) => {
+      const kept = readTransactions().filter((pending) => pending.state !== transaction.state);
+      write(transactionKey, [transaction, ...kept].slice(0, MAX_TRANSACTIONS));
     },
 
-    clearTransaction: () => remove(transactionKey),
+    /** The transaction a callback's `state` belongs to, or the newest one when asked for none. */
+    readTransaction: (state?: string) => {
+      const pending = readTransactions();
+      if (state === undefined) return pending[0] ?? null;
+      return pending.find((transaction) => transaction.state === state) ?? null;
+    },
+
+    /** Forgets one transaction, or every one of them when asked for none. */
+    clearTransaction: (state?: string) => {
+      if (state === undefined) return remove(transactionKey);
+      const kept = readTransactions().filter((transaction) => transaction.state !== state);
+      if (kept.length === 0) return remove(transactionKey);
+      write(transactionKey, kept);
+    },
   };
 };
 

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -8,7 +8,18 @@
 
 /** Envelope every endpoint answers with, except the OAuth token endpoint. */
 export type ApiEnvelope<T> = { code: number; data: T };
-export type ApiErrorBody = { code: number; error: string };
+/**
+ * A rejection, in any of the three shapes the service answers with: its own `{ code, error }`, the
+ * OAuth endpoints' `{ error, error_description }` (RFC 6749 §5.2, and no `code`), and a schema
+ * failure's array of issues. `parseError` reads all three.
+ */
+export type ApiErrorBody = {
+  code?: number;
+  error: string | Array<{message?: string} | string>;
+  /** The sentence, when the code beside it is a machine token like `invalid_grant`. */
+  error_description?: string;
+  message?: string;
+};
 
 /* ── Service metadata ─────────────────────────────────────────────────────── */
 

--- a/src/lib/auth/useResource.ts
+++ b/src/lib/auth/useResource.ts
@@ -11,10 +11,19 @@ export type Resource<T> = {
   reload: () => void;
 };
 
+/**
+ * Turns a thrown cause into something a view can show.
+ *
+ * The two auth errors carry text written for a person. Anything else reaching here is a programming
+ * fault, and its `message` is written for whoever is reading a stack trace — a truncated response
+ * once put "Expected ',' or '}' after property value in JSON at position 29" in front of a user.
+ * Those collapse to one translated line, and the detail goes where it is useful instead.
+ */
 export const describeError = (cause: unknown) => {
   if (cause instanceof AuthNetworkError) return {message: "network", status: null};
   if (cause instanceof AuthApiError) return {message: cause.message, status: cause.status};
-  return {message: cause instanceof Error ? cause.message : String(cause), status: null};
+  console.error("Unexpected failure while talking to the auth service:", cause);
+  return {message: "unexpected", status: null};
 };
 
 /**

--- a/src/lib/cms/config.ts
+++ b/src/lib/cms/config.ts
@@ -22,6 +22,27 @@ export const CMS_ROUTE = "/cms";
 export const CMS_SIGN_IN_ROUTE = `${CMS_ROUTE}/sign-in`;
 export const CMS_CALLBACK_ROUTE = `${CMS_ROUTE}/callback`;
 
+/** Where the interface answered before it moved off `/apps/cms`; `router.tsx` still forwards it. */
+export const CMS_LEGACY_ROUTE = "/apps/cms";
+
+/**
+ * Redirect URI the CMS asks the auth service to send the browser back to.
+ *
+ * It is deliberately *not* `CMS_CALLBACK_ROUTE`. The application is still registered under the
+ * pre-move `/apps/cms/callback`, and the authorization server matches redirect URIs by exact
+ * string: asking for the new path is refused outright — `400 redirect_uri is not registered for
+ * this client` — on every entry point, before any redirect this site could forward can happen.
+ * Quoting the registered path instead lands the browser on `/apps/cms/callback`, which
+ * `router.tsx` forwards to the callback screen with the code and state intact, and the exchange
+ * quotes the same registered value because it reads this config rather than the address bar.
+ *
+ * Once the application carries `<origin>/cms/callback` among its redirect URIs — Admin →
+ * Applications in the auth interface — set `VITE_CMS_REDIRECT_PATH=/cms/callback` (or change the
+ * default here) and the extra hop disappears.
+ */
+export const CMS_REDIRECT_PATH =
+  import.meta.env.VITE_CMS_REDIRECT_PATH ?? `${CMS_LEGACY_ROUTE}/callback`;
+
 /**
  * Where the interface's own sections live. Kept here rather than spelled out at each call site so
  * a link and the route it points at cannot drift apart.
@@ -54,6 +75,7 @@ export const CMS_AUTH_CONFIG: AuthClientConfig = {
   scope: AUTH_SCOPE,
   signInRoute: CMS_SIGN_IN_ROUTE,
   callbackRoute: CMS_CALLBACK_ROUTE,
+  redirectPath: CMS_REDIRECT_PATH,
   defaultReturnTo: CMS_ROUTE,
   returnToPrefix: CMS_ROUTE,
 };

--- a/src/pages/auth/account/account.tsx
+++ b/src/pages/auth/account/account.tsx
@@ -1,7 +1,9 @@
 import type {ReactNode} from "react";
 import {useTranslation} from "react-i18next";
+import {ArrowClockwise} from "@phosphor-icons/react";
 import {Alert} from "@/components/ui/alert.tsx";
 import {Badge} from "@/components/ui/badge/badge.tsx";
+import {Button} from "@/components/ui/button/button.tsx";
 import {useAuth} from "@/lib/auth/auth-context.ts";
 import {formatDateTime} from "@/lib/auth/format.ts";
 import {AuthShell} from "@/pages/auth/components/auth-shell.tsx";
@@ -13,18 +15,40 @@ import {SessionsPanel} from "@/pages/auth/account/sessions-panel.tsx";
 /** What the account holds: profile, granted access, linked providers and live sessions. */
 export const Account = () => {
   const {t, i18n} = useTranslation();
-  const {me, error} = useAuth();
+  const {me, error, reload} = useAuth();
 
-  if (!me) return null;
+  const heading = (
+    <div className="mb-8">
+      <h1 className="text-[clamp(26px,4vw,36px)] leading-tight text-text">{t("auth:account.title")}</h1>
+      <p className="mt-2 max-w-2xl text-sm leading-relaxed text-neutral-400">{t("auth:account.subtitle")}</p>
+    </div>
+  );
+
+  /*
+   * The session outlived a profile load that failed: the provider keeps a session whose fault says
+   * nothing about the tokens, which leaves this screen with nothing to render. Rendering nothing is
+   * what it used to do — a page with only the footer on it, no message, and no way to reach the
+   * shell's sign-out. The shell stays; what is missing is said, with a way to ask again.
+   */
+  if (!me) {
+    return (
+      <AuthShell title={t("auth:account.title")}>
+        {heading}
+        <Alert tone="error" title={t("auth:common.failed")} className="mb-5">
+          {t(`auth:errors.${error ?? "unexpected"}`, {defaultValue: t("auth:errors.unexpected")})}
+        </Alert>
+        <Button variant="secondary" onClick={() => void reload()} data-fs-hover>
+          <ArrowClockwise size={16}/> {t("auth:common.retry")}
+        </Button>
+      </AuthShell>
+    );
+  }
 
   const {user, roles, permissions, application_id} = me;
 
   return (
     <AuthShell title={t("auth:account.title")}>
-      <div className="mb-8">
-        <h1 className="text-[clamp(26px,4vw,36px)] leading-tight text-text">{t("auth:account.title")}</h1>
-        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-neutral-400">{t("auth:account.subtitle")}</p>
-      </div>
+      {heading}
 
       {error === "network" && (
         <Alert tone="error" className="mb-6">{t("auth:errors.network")}</Alert>

--- a/src/pages/auth/admin/users-panel.tsx
+++ b/src/pages/auth/admin/users-panel.tsx
@@ -86,7 +86,8 @@ export const UsersPanel = () => {
                 <Avatar name={user.name} email={user.email} picture={user.picture} size={36}/>
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm text-text">{user.name || user.email}</p>
-                  <p className="truncate text-[13px] text-neutral-500">{user.email}</p>
+                  {/* An account with no name is already identified by the line above. */}
+                  {user.name && <p className="truncate text-[13px] text-neutral-500">{user.email}</p>}
                 </div>
                 {user.status && user.status !== "active" && (
                   <Badge variant="outline" size="sm">

--- a/src/pages/auth/authorize.tsx
+++ b/src/pages/auth/authorize.tsx
@@ -10,6 +10,7 @@ import {Button} from "@/components/ui/button/button.tsx";
 import {Field, Input} from "@/components/ui/input.tsx";
 import {Spinner} from "@/components/ui/spinner.tsx";
 import {loadAuthorizationRequest, requestParkedMagicLink} from "@/lib/auth/authorize.ts";
+import {looksLikeEmail} from "@/lib/auth/format.ts";
 import type {PendingAuthorizationProvider} from "@/lib/auth/types.ts";
 import {describeError, useResource} from "@/lib/auth/useResource.ts";
 
@@ -56,10 +57,15 @@ export const Authorize = () => {
     event.preventDefault();
     if (!handle) return;
     setError(null);
+
+    /* Same as the site's own sign-in: `noValidate` means nothing else checks the shape. */
+    const recipient = address.trim();
+    if (!looksLikeEmail(recipient)) return setError("invalid-email");
+
     setBusy("magic_link");
     try {
-      const {expires_in} = await requestParkedMagicLink(handle, address.trim());
-      setPhase({kind: "sent", email: address.trim(), expiresIn: expires_in});
+      const {expires_in} = await requestParkedMagicLink(handle, recipient);
+      setPhase({kind: "sent", email: recipient, expiresIn: expires_in});
     } catch (cause) {
       setError(describeError(cause).message);
     } finally {

--- a/src/pages/cms/components/legacy-redirect.tsx
+++ b/src/pages/cms/components/legacy-redirect.tsx
@@ -1,13 +1,15 @@
 import {Navigate, useLocation} from "react-router-dom";
-import {CMS_ROUTE} from "@/lib/cms/config.ts";
+import {CMS_LEGACY_ROUTE, CMS_ROUTE} from "@/lib/cms/config.ts";
 
 /**
- * The CMS used to live at `/apps/cms`. Old links — and, until the application is re-registered on
- * the auth service, the old redirect URI — still land there, so the whole sub-path is forwarded
- * with its query string intact rather than dropped on the new landing.
+ * The CMS used to live at `/apps/cms`. Old links still land there — and so does every sign-in,
+ * because that is the path the application is registered under on the auth service
+ * (`CMS_REDIRECT_PATH`). The whole sub-path is therefore forwarded with its query string intact
+ * rather than dropped on the new landing: the callback screen needs the `code` and `state` the
+ * service appended here.
  */
 export const CmsLegacyRedirect = () => {
   const {pathname, search, hash} = useLocation();
-  const rest = pathname.replace(/^\/apps\/cms/, "");
+  const rest = pathname.startsWith(CMS_LEGACY_ROUTE) ? pathname.slice(CMS_LEGACY_ROUTE.length) : "";
   return <Navigate to={`${CMS_ROUTE}${rest}${search}${hash}`} replace/>;
 };

--- a/src/translations/en/auth.json
+++ b/src/translations/en/auth.json
@@ -217,6 +217,9 @@
     "network": "The auth service could not be reached. Check your connection and try again.",
     "missing-code": "This address is missing the authorization code the provider should have sent.",
     "missing-transaction": "This browser has no record of the sign-in that started this link. Start again from the sign-in page.",
-    "state-mismatch": "The sign-in could not be verified. Start again from the sign-in page."
+    "state-mismatch": "The sign-in could not be verified. Start again from the sign-in page.",
+    "invalid-email": "Enter an email address in the form name@example.com.",
+    "unexpected": "Something went wrong on our side. Try again in a moment.",
+    "malformed-response": "The service sent an answer this browser could not read. Try again in a moment."
   }
 }

--- a/src/translations/en/cms.json
+++ b/src/translations/en/cms.json
@@ -147,6 +147,9 @@
     "state-mismatch": "The sign-in could not be verified. Start again from the CMS sign-in page.",
     "forbidden": "Your account is not allowed to do this.",
     "not_found": "That record no longer exists.",
-    "conflict": "Another record already uses that slug."
+    "conflict": "Another record already uses that slug.",
+    "invalid-email": "Enter an email address in the form name@example.com.",
+    "unexpected": "Something went wrong on our side. Try again in a moment.",
+    "malformed-response": "The service sent an answer this browser could not read. Try again in a moment."
   }
 }

--- a/src/translations/es/auth.json
+++ b/src/translations/es/auth.json
@@ -217,6 +217,9 @@
     "network": "No se pudo contactar al servicio de autenticación. Revisa tu conexión e inténtalo de nuevo.",
     "missing-code": "A esta dirección le falta el código de autorización que el proveedor debía enviar.",
     "missing-transaction": "Este navegador no tiene registro del inicio de sesión que originó este enlace. Empieza de nuevo desde la página de inicio de sesión.",
-    "state-mismatch": "No se pudo verificar el inicio de sesión. Empieza de nuevo desde la página de inicio de sesión."
+    "state-mismatch": "No se pudo verificar el inicio de sesión. Empieza de nuevo desde la página de inicio de sesión.",
+    "invalid-email": "Escribe una dirección de correo con el formato nombre@ejemplo.com.",
+    "unexpected": "Algo falló de nuestro lado. Inténtalo de nuevo en un momento.",
+    "malformed-response": "El servicio envió una respuesta que este navegador no pudo leer. Inténtalo de nuevo en un momento."
   }
 }

--- a/src/translations/es/cms.json
+++ b/src/translations/es/cms.json
@@ -147,6 +147,9 @@
     "state-mismatch": "No se pudo verificar el inicio de sesión. Empieza de nuevo desde la página de inicio de sesión del CMS.",
     "forbidden": "Tu cuenta no puede hacer esto.",
     "not_found": "Ese registro ya no existe.",
-    "conflict": "Otro registro ya usa ese slug."
+    "conflict": "Otro registro ya usa ese slug.",
+    "invalid-email": "Escribe una dirección de correo con el formato nombre@ejemplo.com.",
+    "unexpected": "Algo falló de nuestro lado. Inténtalo de nuevo en un momento.",
+    "malformed-response": "El servicio envió una respuesta que este navegador no pudo leer. Inténtalo de nuevo en un momento."
   }
 }


### PR DESCRIPTION
## The blocker

**CMS sign-in was impossible from anywhere** — production and local alike, on both providers.

`franciscosolis-cms` is still registered under the pre-move `/apps/cms/callback`, the interface asks for `/cms/callback`, and the authorization server matches redirect URIs by exact string. Every entry point was refused before the flow started:

```
POST /auth/magic-link            → 400 {"code":400,"error":"redirect_uri is not registered for this client"}
GET  /auth/oauth/google/authorize → 400 (same)
GET  /auth/oauth/authorize        → 400 (same)
```

Verified against the live service, all four cells:

| client | redirect_uri | |
|---|---|---|
| `franciscosolis-web` | `https://franciscosolis.cl/auth/callback` | 302 ✅ |
| `franciscosolis-cms` | `https://franciscosolis.cl/cms/callback` | **400** |
| `franciscosolis-cms` | `https://franciscosolis.cl/apps/cms/callback` | 302 ✅ |
| `franciscosolis-web` | `http://localhost:5173/auth/callback` | 302 ✅ |

The `/apps/cms/*` forward in `router.tsx` was expected to cover this and cannot: the refusal happens *before* the browser is sent anywhere. Pointing `callbackRoute` at the old path alone would not work either, since the token exchange re-sends `redirect_uri` and it must match.

### The fix

`AuthClientConfig` now separates the path the service redirects **to** (`redirectPath`) from the route that **redeems** the code (`callbackRoute`). The CMS quotes the registered path; the landing is forwarded to `/cms/callback` with `code` and `state` intact; and the exchange quotes the same string, because `redirectUri()` derives it from config rather than from the address bar — RFC 6749 §4.1.3.

Setting `VITE_CMS_REDIRECT_PATH=/cms/callback` retires the extra hop once the application carries the new URI (**Admin → Applications**). Nothing changes for `franciscosolis-web`.

**Verified after the change:** `POST /auth/magic-link` with `redirect_uri=…/apps/cms/callback` → **202**, and `/apps/cms/callback?code=…&state=…` forwards to `/cms/callback?code=…&state=…` unchanged.

## Also fixed, found while testing that flow end to end

**Error messages that said nothing**
- A validation failure rendered `HTTP 400`; the service had said *"A valid email address is required"* — in an `error` **array** the parser only read as a string.
- A token failure rendered the bare code `invalid_grant`, discarding `error_description: "Unknown authorization code"`.
- Both sign-in forms carry `noValidate`, so `required` / `type=email` were inert and an empty box round-tripped to the server. Now caught locally, in both locales.

**Failure states**
- `/auth/account` rendered a page with only the footer when the service was unreachable — no message, no retry, no sign-out — because the provider keeps the session on a fault (`me = null`) and the screen opened with `if (!me) return null`. `/auth/admin` and `/cms` already handled the same condition correctly.
- The session layer read a **5xx** as "not signed in" and showed a sign-in form for a server hiccup; only 401/403 does that now.
- A truncated body put V8's `Expected ',' or '}' … at position 29` in front of the user.
- Nothing bounded a read, so a service that accepted the connection and never answered held *"Restoring your session…"* on screen indefinitely (measured: 30 s on `/auth/account`, ≈70 s on `/cms`). Reads now have a 20 s deadline — reads only, since aborting a write mid-flight says nothing about whether it landed.

**Correctness**
- `?return_to=/\evil.com` and `/%09//evil.com` passed the leading-slash check: the URL parser reads a backslash as a slash and strips tabs, so both named another host. Values are resolved against this origin and kept only if they stayed here.
- One transaction slot meant a second magic link silently invalidated the first; opening it failed as `state-mismatch` — tampering, for an ordinary thing. Transactions are keyed by state now (cap 5, existing single-object records upgrade in place, so links already in inboxes stay redeemable).
- A refresh refused because another tab had already rotated the token signed **both** tabs out of a live session.
- A token record that is present but unusable (`{}`, `null`, half-written) was kept forever, so every visit to a protected route flashed a loader and bounced back to sign-in.

**Privacy / hardening**
- Analytics received `/apps/auth?request=<handle>` verbatim — a credential that needs no auth and stays readable for the life of the parked request, with the signing-in address in `login_hint` beside it. The sensitive params are stripped before the page_view; the visit is still counted.
- `public/_headers` denies framing on the screens that hold a session (the sign-in screen was fully interactive inside a cross-origin iframe) and sets `nosniff` + `Referrer-Policy` site-wide.
- `pnpm lint` ran `eslint .`, which is not a dependency and has no config here; it now runs oxlint, which the repo is actually set up for.

## Not fixed here — needs the auth service, not this repo

1. **Register `<origin>/cms/callback`** for `franciscosolis-cms` and flip `VITE_CMS_REDIRECT_PATH`. This PR makes sign-in work today; that makes the hop unnecessary.
2. **`/cms` CORS matches origins by suffix** — `https://evilfranciscosolis.cl` and `https://xfranciscosolis.cl` are echoed back as allowed. Limited blast radius (no `allow-credentials`), but it is a real hole. `/auth` uses a strict allowlist and is fine.
3. **HSTS is `max-age=0`** on both hosts, on an origin that holds refresh tokens in `localStorage`. Deliberately left alone — enabling it is a zone-level change with a long, hard-to-reverse tail.
4. **A rejected authorize request renders as raw JSON** on `api.franciscosolis.cl`, outside the site, with no way back. The app cannot intercept it: that endpoint sends no CORS headers, so a pre-flight check would always fail open.

## Testing

Playwright against the live site and a local dev server, plus direct API probes.

- Full route sweep (15 routes, site + auth + CMS + hosted authorize): all render, **zero console errors**, guards redirect with `return_to` preserved.
- Every fix above re-tested against the exact failure it addresses — network abort, 500 with an HTML body, truncated JSON, 30 s stall, four corrupt-token shapes, hostile `return_to` values, three concurrent magic links.
- `pnpm build` (`tsc -b && vite build`) clean; `pnpm lint` clean apart from one pre-existing warning in `src/legacy/`.

No account or mailbox was available, so the leg past a *successful* code exchange is still uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176qwMdqEiokNtDV67h1anQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0176qwMdqEiokNtDV67h1anQ)_