### PR TITLE
auth: stop sending CMS requests with no token behind them

### DIFF
--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -141,7 +141,17 @@ export const createHttpClient = (baseUrl: string, session: SessionStore) => {
    */
   const request = async <T>(path: string, options: RequestOptions = {}): Promise<T> => {
     const authenticated = options.auth !== false;
-    let response = await send(path, options, authenticated ? await session.getAccessToken() : null);
+    const token = authenticated ? await session.getAccessToken() : null;
+
+    /*
+     * No token in hand — the store has none, or its refresh came back revoked. Sending the request
+     * anyway is what put unauthenticated calls in front of the API: the service answered "A Bearer
+     * access token is required" on every screen while the interface still believed it was signed
+     * in, so the failure read as a broken client instead of as a session that had ended.
+     */
+    if (authenticated && !token) throw new AuthApiError(401, "session-expired");
+
+    let response = await send(path, options, token);
 
     if (response.status === 401 && authenticated) {
       const outcome = await session.refreshSession();

--- a/src/lib/auth/flow.ts
+++ b/src/lib/auth/flow.ts
@@ -99,7 +99,9 @@ export const createAuthFlow = (
       code_verifier: transaction.code_verifier,
     });
 
-    session.startSession(tokens);
+    /* Nothing to sign in with: better a failed callback than a session that is one only in name. */
+    if (!session.startSession(tokens)) throw new AuthApiError(502, "malformed-response");
+
     storage.clearTransaction(transaction.state);
     return transaction.return_to || config.defaultReturnTo;
   };

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -2,7 +2,7 @@ import {WEB_AUTH_CONFIG} from "@/lib/auth/config.ts";
 import type {AuthClientConfig} from "@/lib/auth/config.ts";
 import {createAuthStorage, isExpired, toStoredTokens} from "@/lib/auth/storage.ts";
 import type {StoredTokens} from "@/lib/auth/storage.ts";
-import type {TokenResponse} from "@/lib/auth/types.ts";
+import type {ApiEnvelope, TokenResponse} from "@/lib/auth/types.ts";
 
 /**
  * Owns the token lifecycle of one application outside React, so refreshing survives re-renders,
@@ -52,8 +52,11 @@ export const createSessionStore = (config: AuthClientConfig) => {
     };
   };
 
-  const startSession = (response: TokenResponse) => {
-    const tokens = toStoredTokens(response);
+  /** Stores the answer to a token request. `null` when the body was not a usable token answer. */
+  const startSession = (response: TokenResponse | ApiEnvelope<TokenResponse>) => {
+    const tokens = toStoredTokens(response, storage.readTokens());
+    if (!tokens) return null;
+
     storage.writeTokens(tokens);
     notify(tokens);
     return tokens;
@@ -66,7 +69,15 @@ export const createSessionStore = (config: AuthClientConfig) => {
 
   const performRefresh = async (): Promise<RefreshOutcome> => {
     const current = storage.readTokens();
-    if (!current?.refresh_token) return {status: "revoked"};
+    if (!current?.refresh_token) {
+      /*
+       * There is nothing left to refresh with, so the record is spent whatever else it holds.
+       * Clearing it is what ends the session everywhere at once: left in place, the guards kept
+       * reading it as "signed in" while every request went out with no token behind it.
+       */
+      if (current) endSession();
+      return {status: "revoked"};
+    }
 
     let response: Response;
     try {
@@ -103,7 +114,14 @@ export const createSessionStore = (config: AuthClientConfig) => {
       return {status: "revoked"};
     }
 
-    return {status: "refreshed", tokens: startSession((await response.json()) as TokenResponse)};
+    const rotated = startSession((await response.json()) as TokenResponse);
+
+    /*
+     * A 200 that is not a token answer — a proxy that rewrote the body, a shape this client does
+     * not know — says nothing about the chain, so the stored pair stands and the caller retries.
+     * What must not happen is storing it: that is what produced a "session" with no token in it.
+     */
+    return rotated ? {status: "refreshed", tokens: rotated} : {status: "unavailable"};
   };
 
   /** Exchanges the stored refresh token for a fresh pair. Concurrent callers share one request. */
@@ -121,7 +139,15 @@ export const createSessionStore = (config: AuthClientConfig) => {
    */
   const getAccessToken = async () => {
     const tokens = storage.readTokens();
-    if (!tokens) return null;
+    if (!tokens) {
+      /*
+       * Nothing usable is left: no record, or one the store just discarded as unreadable. That
+       * discard happens without a `storage` event of its own, so it is announced here — otherwise a
+       * screen that was rendered while the session still looked live keeps that view for good.
+       */
+      notify(null);
+      return null;
+    }
     if (!isExpired(tokens)) return tokens.access_token;
 
     const outcome = await refreshSession();

--- a/src/lib/auth/storage.ts
+++ b/src/lib/auth/storage.ts
@@ -1,4 +1,4 @@
-import type {TokenResponse} from "@/lib/auth/types.ts";
+import type {ApiEnvelope, TokenResponse} from "@/lib/auth/types.ts";
 
 /**
  * Persistence for the sign-in flow, namespaced per application so the site and the CMS can hold a
@@ -152,12 +152,34 @@ export const createAuthStorage = (namespace: string) => {
   };
 };
 
-export const toStoredTokens = (response: TokenResponse): StoredTokens => ({
-  access_token: response.access_token,
-  refresh_token: response.refresh_token,
-  session_id: response.session_id,
-  scope: response.scope,
-  expires_at: Date.now() + response.expires_in * 1000,
-});
+/** The token answer itself, whether or not it arrived inside the API's `{code, data}` envelope. */
+const tokenPayload = (body: TokenResponse | ApiEnvelope<TokenResponse>): Partial<TokenResponse> =>
+  body && typeof body === "object" && "data" in body ? body.data : body;
+
+/**
+ * The record to store for a token answer, or `null` when the answer was not one.
+ *
+ * Both halves are about the same failure: a record that reads as a session and cannot be used as
+ * one. Without an `access_token` there is no session to write at all — storing the shape anyway
+ * left every guard saying "signed in" while `readTokens` discarded the record on the next read,
+ * which is what sent unauthenticated requests to the API for the rest of the visit. And a refresh
+ * answer may leave `refresh_token` out — RFC 6749 §6 reads that as "keep the one you have" — so the
+ * stored one is carried over rather than written away.
+ */
+export const toStoredTokens = (
+  body: TokenResponse | ApiEnvelope<TokenResponse>,
+  previous?: StoredTokens | null,
+): StoredTokens | null => {
+  const response = tokenPayload(body);
+  if (typeof response?.access_token !== "string" || !response.access_token) return null;
+
+  return {
+    access_token: response.access_token,
+    refresh_token: response.refresh_token ?? previous?.refresh_token ?? "",
+    session_id: response.session_id ?? previous?.session_id ?? "",
+    scope: response.scope ?? null,
+    expires_at: Date.now() + (response.expires_in ?? 0) * 1000,
+  };
+};
 
 export const isExpired = (tokens: StoredTokens) => Date.now() >= tokens.expires_at - EXPIRY_SKEW_MS;

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -82,7 +82,8 @@ export type TokenResponse = {
   access_token: string;
   token_type: "Bearer";
   expires_in: number;
-  refresh_token: string;
+  /** Omitted by a refresh answer that is not rotating the token; the stored one then stands. */
+  refresh_token?: string;
   scope: string | null;
   session_id: string;
 };

--- a/src/translations/en/auth.json
+++ b/src/translations/en/auth.json
@@ -215,6 +215,7 @@
   },
   "errors": {
     "network": "The auth service could not be reached. Check your connection and try again.",
+    "session-expired": "Your session has ended. Sign in again.",
     "missing-code": "This address is missing the authorization code the provider should have sent.",
     "missing-transaction": "This browser has no record of the sign-in that started this link. Start again from the sign-in page.",
     "state-mismatch": "The sign-in could not be verified. Start again from the sign-in page.",

--- a/src/translations/en/cms.json
+++ b/src/translations/en/cms.json
@@ -142,6 +142,7 @@
   },
   "errors": {
     "network": "The service could not be reached. Check your connection and try again.",
+    "session-expired": "Your CMS session has ended. Sign in again to keep editing.",
     "missing-code": "This address is missing the authorization code the provider should have sent.",
     "missing-transaction": "This browser has no record of the sign-in that started this link. Start again from the CMS sign-in page.",
     "state-mismatch": "The sign-in could not be verified. Start again from the CMS sign-in page.",

--- a/src/translations/es/auth.json
+++ b/src/translations/es/auth.json
@@ -215,6 +215,7 @@
   },
   "errors": {
     "network": "No se pudo contactar al servicio de autenticación. Revisa tu conexión e inténtalo de nuevo.",
+    "session-expired": "Tu sesión terminó. Vuelve a iniciar sesión.",
     "missing-code": "A esta dirección le falta el código de autorización que el proveedor debía enviar.",
     "missing-transaction": "Este navegador no tiene registro del inicio de sesión que originó este enlace. Empieza de nuevo desde la página de inicio de sesión.",
     "state-mismatch": "No se pudo verificar el inicio de sesión. Empieza de nuevo desde la página de inicio de sesión.",

--- a/src/translations/es/cms.json
+++ b/src/translations/es/cms.json
@@ -142,6 +142,7 @@
   },
   "errors": {
     "network": "No se pudo contactar al servicio. Revisa tu conexión e inténtalo de nuevo.",
+    "session-expired": "Tu sesión del CMS terminó. Vuelve a iniciar sesión para seguir editando.",
     "missing-code": "A esta dirección le falta el código de autorización que el proveedor debía enviar.",
     "missing-transaction": "Este navegador no tiene registro del inicio de sesión que originó este enlace. Empieza de nuevo desde la página de inicio de sesión del CMS.",
     "state-mismatch": "No se pudo verificar el inicio de sesión. Empieza de nuevo desde la página de inicio de sesión del CMS.",


### PR DESCRIPTION
## What was happening

Every CMS screen reached the API unauthenticated: `api.franciscosolis.cl/cms/*` answered
`{"code":401,"error":"A Bearer access token is required"}` while the interface kept showing the
account as signed in — the header still had the email, and the shell only rendered a failed
identity call.

## Why

Three defects in the shared auth layer, one behind the other.

1. **A token answer was stored whatever its shape.** `toStoredTokens` copied `access_token`
   straight out of the body. A body without one produced a record that reads as a session to every
   guard, and that `readTokens` then discards on the next read — silently, since that path has no
   listeners. The store went empty while nothing above it was told, so `getAccessToken()` returned
   `null` for the rest of the visit with the UI none the wiser.
2. **The request layer sent the call anyway.** With no token in hand it still went to the network,
   which is how the service's own "a Bearer access token is required" ended up in front of the
   editor — reading as a broken client rather than as a session that had ended.
3. **A session with nothing left to refresh with was left in place.** `performRefresh` returned
   `revoked` without clearing anything when the record held no refresh token, so the guards kept
   answering "signed in" over an unusable record.

## What changed

- `storage.ts` — `toStoredTokens` returns `null` for a body carrying no `access_token`, reads the
  API's `{code, data}` envelope in case the token endpoint answers in it, and carries over a
  `refresh_token` the answer omitted (RFC 6749 §6 reads that as "keep the one you have"; writing
  `undefined` over it left a record that could never be refreshed again).
- `session.ts` — `startSession` refuses to write an unusable record; a refresh whose body is not a
  token answer counts as `unavailable`, so the stored pair stands and the call retries with it
  rather than with nothing; a refresh with no token to spend now ends the session; and an empty
  read is announced to the listeners, which is what lets a browser already holding a poisoned
  record fall to the sign-in screen instead of keeping a dead view.
- `client.ts` — an authenticated request with no token fails as `session-expired` before it leaves
  the browser.
- `flow.ts` — an exchange that returns no usable tokens fails the callback instead of leaving a
  session that is one only in name.
- `session-expired` copy added to the `auth` and `cms` namespaces, es and en.

## Notes for the reviewer

- The fix is in the layer both applications share, so `/auth` gets it too — the CMS is only where
  it surfaced.
- `TokenResponse.refresh_token` is now optional, which is what the spec allows on a refresh.
- Verified by driving the real module graph (`src/lib/cms/client.ts`) under stubbed
  `localStorage`/`fetch`, over 8 cases: bearer present on a live session, record with no refresh
  token, refused refresh, non-rotating refresh, poisoned refresh body, enveloped refresh body,
  pre-existing corrupt record, and public endpoints still going out unauthenticated. `tsc -b` and
  `oxlint` are clean.
- Still open: which answer wrote the bad record in the first place. The client is now robust to
  both shapes, but the response body of `POST /auth/oauth/token` on a refresh would confirm whether
  the service envelopes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)